### PR TITLE
feat(api): @hono/zod-openapi を使って全 API ルートを書き直す

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,11 +16,12 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.14.4",
+    "@hono/swagger-ui": "^0.6.1",
+    "@hono/zod-openapi": "^0.19.10",
     "@wifiman/shared": "workspace:*",
     "better-auth": "^1.6.5",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.7.10",
-    "@hono/zod-validator": "^0.4.3",
     "nodemailer": "^6.10.1",
     "postgres": "^3.4.5",
     "zod": "^3.25.17"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,6 @@
-import { Hono } from 'hono';
+import { swaggerUI } from '@hono/swagger-ui';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import type { ContextVariableMap } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { auth } from './auth.js';
@@ -15,8 +17,10 @@ import teamRoutes from './routes/teams.js';
 import tournamentRoutes from './routes/tournaments.js';
 import wifiConfigRoutes from './routes/wifiConfigs.js';
 
+type AppEnv = { Variables: ContextVariableMap };
+
 export function createApp() {
-  const app = new Hono();
+  const app = new OpenAPIHono<AppEnv>();
 
   // CORS
   app.use(
@@ -39,9 +43,9 @@ export function createApp() {
   app.use('/api/*', setAuthContext);
 
   // Routes
-  const api = new Hono();
+  const api = new OpenAPIHono<AppEnv>();
 
-  api.route('/tournaments', tournamentRoutes);
+  api.route('/', tournamentRoutes);
   api.route('/', teamRoutes);
   api.route('/', teamAccessRoutes);
   api.route('/', wifiConfigRoutes);
@@ -50,6 +54,16 @@ export function createApp() {
   api.route('/', issueReportRoutes);
   api.route('/', bestPracticeRoutes);
   api.route('/', noticeRoutes);
+
+  // OpenAPI ドキュメント
+  api.doc('/openapi.json', {
+    openapi: '3.1.0',
+    info: { title: 'WiFiMan API', version: '1.0.0' },
+    servers: [{ url: '/api', description: 'WiFiMan API server' }],
+  });
+
+  // Swagger UI
+  api.get('/docs', swaggerUI({ url: '/api/openapi.json' }));
 
   app.route('/api', api);
 

--- a/apps/api/src/routes/bestPractices.ts
+++ b/apps/api/src/routes/bestPractices.ts
@@ -1,53 +1,101 @@
-import { zValidator } from '@hono/zod-validator';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import { CreateBestPracticeSchema, UpdateBestPracticeSchema } from '@wifiman/shared';
 import { eq } from 'drizzle-orm';
-import { Hono } from 'hono';
+import type { ContextVariableMap } from 'hono';
 import { db } from '../db/index.js';
 import { bestPractices } from '../db/schema/index.js';
 import { notFound } from '../errors.js';
 import { requireOperator } from '../middleware/auth.js';
 
-const app = new Hono();
+const app = new OpenAPIHono<{ Variables: ContextVariableMap }>();
+
+const errorSchema = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
 
 // GET /api/tournaments/:tournamentId/best-practices - ベストプラクティス一覧 (public)
-app.get('/tournaments/:tournamentId/best-practices', async (c) => {
-  const { tournamentId } = c.req.param();
+const listBestPractices = createRoute({
+  method: 'get',
+  path: '/tournaments/{tournamentId}/best-practices',
+  tags: ['best-practices'],
+  request: { params: z.object({ tournamentId: z.string() }) },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(z.any()) } },
+      description: 'ベストプラクティス一覧',
+    },
+  },
+});
+app.openapi(listBestPractices, async (c) => {
+  const { tournamentId } = c.req.valid('param');
   const rows = await db
     .select()
     .from(bestPractices)
     .where(eq(bestPractices.tournamentId, tournamentId));
-  return c.json(rows);
+  return c.json(rows, 200);
 });
 
 // POST /api/best-practices - ベストプラクティス作成 (operator)
-app.post(
-  '/best-practices',
-  requireOperator,
-  zValidator('json', CreateBestPracticeSchema),
-  async (c) => {
-    const body = c.req.valid('json');
-    const [row] = await db.insert(bestPractices).values(body).returning();
-    if (!row) throw new Error('insert failed');
-    return c.json(row, 201);
+const createBestPractice = createRoute({
+  method: 'post',
+  path: '/best-practices',
+  tags: ['best-practices'],
+  middleware: [requireOperator] as const,
+  request: {
+    body: { content: { 'application/json': { schema: CreateBestPracticeSchema } }, required: true },
   },
-);
+  responses: {
+    201: {
+      content: { 'application/json': { schema: z.any() } },
+      description: 'ベストプラクティス作成',
+    },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+  },
+});
+app.openapi(createBestPractice, async (c) => {
+  const body = c.req.valid('json');
+  const [row] = await db.insert(bestPractices).values(body).returning();
+  if (!row) throw new Error('insert failed');
+  return c.json(row, 201);
+});
 
 // PATCH /api/best-practices/:id - ベストプラクティス更新 (operator)
-app.patch(
-  '/best-practices/:id',
-  requireOperator,
-  zValidator('json', UpdateBestPracticeSchema),
-  async (c) => {
-    const id = c.req.param('id');
-    const body = c.req.valid('json');
-    const [row] = await db
-      .update(bestPractices)
-      .set({ ...body, updatedAt: new Date() })
-      .where(eq(bestPractices.id, id))
-      .returning();
-    if (!row) throw notFound('ベストプラクティスが見つかりません');
-    return c.json(row);
+const updateBestPractice = createRoute({
+  method: 'patch',
+  path: '/best-practices/{id}',
+  tags: ['best-practices'],
+  middleware: [requireOperator] as const,
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: UpdateBestPracticeSchema } }, required: true },
   },
-);
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.any() } },
+      description: 'ベストプラクティス更新',
+    },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(updateBestPractice, async (c) => {
+  const { id } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const [row] = await db
+    .update(bestPractices)
+    .set({ ...body, updatedAt: new Date() })
+    .where(eq(bestPractices.id, id))
+    .returning();
+  if (!row) throw notFound('ベストプラクティスが見つかりません');
+  return c.json(row, 200);
+});
 
 export default app;

--- a/apps/api/src/routes/deviceSpecs.ts
+++ b/apps/api/src/routes/deviceSpecs.ts
@@ -1,17 +1,43 @@
-import { zValidator } from '@hono/zod-validator';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import { CreateDeviceSpecSchema, UpdateDeviceSpecSchema } from '@wifiman/shared';
 import { eq } from 'drizzle-orm';
-import { Hono } from 'hono';
+import type { ContextVariableMap, MiddlewareHandler } from 'hono';
 import { db } from '../db/index.js';
 import { deviceSpecs } from '../db/schema/index.js';
 import { notFound } from '../errors.js';
 import { requireTeamEditor, requireTeamViewer } from '../middleware/auth.js';
 
-const app = new Hono();
+const app = new OpenAPIHono<{ Variables: ContextVariableMap }>();
+
+const errorSchema = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
+type AppMiddleware = MiddlewareHandler<{ Variables: ContextVariableMap }>;
+
+const resolveDeviceSpecTeamMiddleware: AppMiddleware = async (c, next) => {
+  const id = c.req.param('id') as string;
+  const spec = await db.query.deviceSpecs.findFirst({ where: eq(deviceSpecs.id, id) });
+  if (!spec) throw notFound('機材仕様が見つかりません');
+  c.set('_targetTeamId', spec.teamId);
+  await next();
+};
 
 // GET /api/teams/:teamId/device-specs - 機材仕様一覧 (team_viewer)
-app.get('/teams/:teamId/device-specs', requireTeamViewer('teamId'), async (c) => {
-  const teamId = c.req.param('teamId')!;
+const listDeviceSpecs = createRoute({
+  method: 'get',
+  path: '/teams/{teamId}/device-specs',
+  tags: ['device-specs'],
+  middleware: [requireTeamViewer('teamId')] as const,
+  request: { params: z.object({ teamId: z.string() }) },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(z.any()) } },
+      description: '機材仕様一覧',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+  },
+});
+app.openapi(listDeviceSpecs, async (c) => {
+  const { teamId } = c.req.valid('param');
   const rows = await db.select().from(deviceSpecs).where(eq(deviceSpecs.teamId, teamId));
   // supportedBands は JSON 文字列として保存されているため parse する
   return c.json(
@@ -19,64 +45,93 @@ app.get('/teams/:teamId/device-specs', requireTeamViewer('teamId'), async (c) =>
       ...r,
       supportedBands: JSON.parse(r.supportedBands) as string[],
     })),
+    200,
   );
 });
 
 // POST /api/teams/:teamId/device-specs - 機材仕様作成 (team_editor)
-app.post(
-  '/teams/:teamId/device-specs',
-  requireTeamEditor('teamId'),
-  zValidator('json', CreateDeviceSpecSchema.omit({ teamId: true })),
-  async (c) => {
-    const teamId = c.req.param('teamId')!;
-    const body = c.req.valid('json');
-    const [row] = await db
-      .insert(deviceSpecs)
-      .values({
-        ...body,
-        teamId,
-        supportedBands: JSON.stringify(body.supportedBands),
-      })
-      .returning();
-    if (!row) throw new Error('insert failed');
-    return c.json({ ...row, supportedBands: body.supportedBands }, 201);
+const createDeviceSpec = createRoute({
+  method: 'post',
+  path: '/teams/{teamId}/device-specs',
+  tags: ['device-specs'],
+  middleware: [requireTeamEditor('teamId')] as const,
+  request: {
+    params: z.object({ teamId: z.string() }),
+    body: {
+      content: { 'application/json': { schema: CreateDeviceSpecSchema.omit({ teamId: true }) } },
+      required: true,
+    },
   },
-);
+  responses: {
+    201: { content: { 'application/json': { schema: z.any() } }, description: '機材仕様作成' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+  },
+});
+app.openapi(createDeviceSpec, async (c) => {
+  const { teamId } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const [row] = await db
+    .insert(deviceSpecs)
+    .values({
+      ...body,
+      teamId,
+      supportedBands: JSON.stringify(body.supportedBands),
+    })
+    .returning();
+  if (!row) throw new Error('insert failed');
+  return c.json({ ...row, supportedBands: body.supportedBands }, 201);
+});
 
 // PATCH /api/device-specs/:id - 機材仕様更新 (team_editor)
-app.patch(
-  '/device-specs/:id',
-  async (c, next) => {
-    const id = c.req.param('id')!;
-    const spec = await db.query.deviceSpecs.findFirst({ where: eq(deviceSpecs.id, id) });
-    if (!spec) throw notFound('機材仕様が見つかりません');
-    c.set('_targetTeamId', spec.teamId);
-    await next();
+const patchDeviceSpec = createRoute({
+  method: 'patch',
+  path: '/device-specs/{id}',
+  tags: ['device-specs'],
+  middleware: [resolveDeviceSpecTeamMiddleware, requireTeamEditor('teamId')] as const,
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: UpdateDeviceSpecSchema } }, required: true },
   },
-  requireTeamEditor('teamId'),
-  zValidator('json', UpdateDeviceSpecSchema),
-  async (c) => {
-    const id = c.req.param('id')!;
-    const body = c.req.valid('json');
-    const { supportedBands: supportedBandsArr, ...restBody } = body;
-    const updateData = {
-      ...restBody,
-      ...(supportedBandsArr !== undefined
-        ? { supportedBands: JSON.stringify(supportedBandsArr) }
-        : {}),
-      updatedAt: new Date(),
-    };
-    const [row] = await db
-      .update(deviceSpecs)
-      .set(updateData)
-      .where(eq(deviceSpecs.id, id))
-      .returning();
-    if (!row) throw notFound('機材仕様が見つかりません');
-    return c.json({
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: '機材仕様更新' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(patchDeviceSpec, async (c) => {
+  const { id } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const { supportedBands: supportedBandsArr, ...restBody } = body;
+  const updateData = {
+    ...restBody,
+    ...(supportedBandsArr !== undefined
+      ? { supportedBands: JSON.stringify(supportedBandsArr) }
+      : {}),
+    updatedAt: new Date(),
+  };
+  const [row] = await db
+    .update(deviceSpecs)
+    .set(updateData)
+    .where(eq(deviceSpecs.id, id))
+    .returning();
+  if (!row) throw notFound('機材仕様が見つかりません');
+  return c.json(
+    {
       ...row,
       supportedBands: body.supportedBands ?? JSON.parse(row.supportedBands),
-    });
-  },
-);
+    },
+    200,
+  );
+});
 
 export default app;

--- a/apps/api/src/routes/issueReports.ts
+++ b/apps/api/src/routes/issueReports.ts
@@ -1,17 +1,27 @@
-import { zValidator } from '@hono/zod-validator';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import { CreateIssueReportSchema, UpdateIssueReportSchema } from '@wifiman/shared';
 import { eq } from 'drizzle-orm';
-import { Hono } from 'hono';
+import type { ContextVariableMap } from 'hono';
 import { db } from '../db/index.js';
 import { deviceSpecs, issueReports, wifiConfigs } from '../db/schema/index.js';
-import { notFound } from '../errors.js';
-import { setAuthContext } from '../middleware/auth.js';
+import { forbidden, notFound, unauthorized } from '../errors.js';
 
-const app = new Hono();
+const app = new OpenAPIHono<{ Variables: ContextVariableMap }>();
+
+const errorSchema = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
 
 // GET /api/tournaments/:tournamentId/issue-reports - 報告一覧 (team_viewer)
-app.get('/tournaments/:tournamentId/issue-reports', setAuthContext, async (c) => {
-  const tournamentId = c.req.param('tournamentId')!;
+const listIssueReports = createRoute({
+  method: 'get',
+  path: '/tournaments/{tournamentId}/issue-reports',
+  tags: ['issue-reports'],
+  request: { params: z.object({ tournamentId: z.string() }) },
+  responses: {
+    200: { content: { 'application/json': { schema: z.array(z.any()) } }, description: '報告一覧' },
+  },
+});
+app.openapi(listIssueReports, async (c) => {
+  const { tournamentId } = c.req.valid('param');
   const authCtx = c.get('auth');
   const rows = await db
     .select()
@@ -20,85 +30,114 @@ app.get('/tournaments/:tournamentId/issue-reports', setAuthContext, async (c) =>
 
   // チームトークン保持者は自チームの報告のみ
   if (authCtx?.teamId && authCtx.userRole !== 'operator') {
-    return c.json(rows.filter((r) => r.teamId === authCtx.teamId));
+    return c.json(
+      rows.filter((r) => r.teamId === authCtx.teamId),
+      200,
+    );
   }
-  return c.json(rows);
+  return c.json(rows, 200);
 });
 
 // POST /api/tournaments/:tournamentId/issue-reports - 報告作成 (team_editor)
-app.post(
-  '/tournaments/:tournamentId/issue-reports',
-  setAuthContext,
-  zValidator('json', CreateIssueReportSchema.omit({ tournamentId: true })),
-  async (c) => {
-    const tournamentId = c.req.param('tournamentId')!;
-    const body = c.req.valid('json');
-    const authCtx = c.get('auth');
+const createIssueReport = createRoute({
+  method: 'post',
+  path: '/tournaments/{tournamentId}/issue-reports',
+  tags: ['issue-reports'],
+  request: {
+    params: z.object({ tournamentId: z.string() }),
+    body: {
+      content: {
+        'application/json': { schema: CreateIssueReportSchema.omit({ tournamentId: true }) },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    201: { content: { 'application/json': { schema: z.any() } }, description: '報告作成' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+  },
+});
+app.openapi(createIssueReport, async (c) => {
+  const { tournamentId } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const authCtx = c.get('auth');
 
-    // チームトークンが必要 (またはoperator)
-    if (!authCtx?.userId && !authCtx?.teamId) {
-      return c.json({ error: { code: 'UNAUTHORIZED', message: '認証が必要です' } }, 401);
-    }
+  // チームトークンが必要 (またはoperator)
+  if (!authCtx?.userId && !authCtx?.teamId) {
+    throw unauthorized('認証が必要です');
+  }
 
-    let finalBody = { ...body };
+  let finalBody = { ...body };
 
-    // wifiConfigId 指定時の自動補完
-    if (body.wifiConfigId) {
-      const config = await db.query.wifiConfigs.findFirst({
-        where: eq(wifiConfigs.id, body.wifiConfigId),
-      });
-      if (config) {
-        finalBody = {
-          ...finalBody,
-          band: finalBody.band ?? config.band,
-          channel: finalBody.channel ?? config.channel,
-          channelWidthMHz: finalBody.channelWidthMHz ?? config.channelWidthMHz ?? undefined,
-        };
+  // wifiConfigId 指定時の自動補完
+  if (body.wifiConfigId) {
+    const config = await db.query.wifiConfigs.findFirst({
+      where: eq(wifiConfigs.id, body.wifiConfigId),
+    });
+    if (config) {
+      finalBody = {
+        ...finalBody,
+        band: finalBody.band ?? config.band,
+        channel: finalBody.channel ?? config.channel,
+        channelWidthMHz: finalBody.channelWidthMHz ?? config.channelWidthMHz ?? undefined,
+      };
 
-        // AP 機材モデルの自動補完
-        if (!finalBody.apDeviceModel && config.apDeviceId) {
-          const apDevice = await db.query.deviceSpecs.findFirst({
-            where: eq(deviceSpecs.id, config.apDeviceId),
-          });
-          if (apDevice) finalBody.apDeviceModel = apDevice.model;
-        }
+      // AP 機材モデルの自動補完
+      if (!finalBody.apDeviceModel && config.apDeviceId) {
+        const apDevice = await db.query.deviceSpecs.findFirst({
+          where: eq(deviceSpecs.id, config.apDeviceId),
+        });
+        if (apDevice) finalBody.apDeviceModel = apDevice.model;
+      }
 
-        // クライアント機材モデルの自動補完
-        if (!finalBody.clientDeviceModel && config.clientDeviceId) {
-          const clientDevice = await db.query.deviceSpecs.findFirst({
-            where: eq(deviceSpecs.id, config.clientDeviceId),
-          });
-          if (clientDevice) finalBody.clientDeviceModel = clientDevice.model;
-        }
+      // クライアント機材モデルの自動補完
+      if (!finalBody.clientDeviceModel && config.clientDeviceId) {
+        const clientDevice = await db.query.deviceSpecs.findFirst({
+          where: eq(deviceSpecs.id, config.clientDeviceId),
+        });
+        if (clientDevice) finalBody.clientDeviceModel = clientDevice.model;
       }
     }
+  }
 
-    const [row] = await db
-      .insert(issueReports)
-      .values({
-        ...finalBody,
-        tournamentId,
-        mitigationTried: finalBody.mitigationTried
-          ? JSON.stringify(finalBody.mitigationTried)
-          : null,
-        syncStatus: 'synced',
-      })
-      .returning();
-    if (!row) throw new Error('insert failed');
+  const [row] = await db
+    .insert(issueReports)
+    .values({
+      ...finalBody,
+      tournamentId,
+      mitigationTried: finalBody.mitigationTried ? JSON.stringify(finalBody.mitigationTried) : null,
+      syncStatus: 'synced',
+    })
+    .returning();
+  if (!row) throw new Error('insert failed');
 
-    return c.json(
-      {
-        ...row,
-        mitigationTried: row.mitigationTried ? JSON.parse(row.mitigationTried) : null,
-      },
-      201,
-    );
-  },
-);
+  return c.json(
+    {
+      ...row,
+      mitigationTried: row.mitigationTried ? JSON.parse(row.mitigationTried) : null,
+    },
+    201,
+  );
+});
 
 // GET /api/issue-reports/:id - 報告詳細 (team_viewer)
-app.get('/issue-reports/:id', setAuthContext, async (c) => {
-  const id = c.req.param('id')!;
+const getIssueReport = createRoute({
+  method: 'get',
+  path: '/issue-reports/{id}',
+  tags: ['issue-reports'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: '報告詳細' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(getIssueReport, async (c) => {
+  const { id } = c.req.valid('param');
   const authCtx = c.get('auth');
   const row = await db.query.issueReports.findFirst({ where: eq(issueReports.id, id) });
   if (!row) throw notFound('報告が見つかりません');
@@ -106,63 +145,86 @@ app.get('/issue-reports/:id', setAuthContext, async (c) => {
   // チームトークン保持者は自チームの報告のみ
   if (authCtx?.teamId && authCtx.userRole !== 'operator') {
     if (row.teamId !== authCtx.teamId) {
-      return c.json({ error: { code: 'FORBIDDEN', message: 'アクセス権限がありません' } }, 403);
+      throw forbidden('アクセス権限がありません');
     }
   }
 
-  return c.json({
-    ...row,
-    mitigationTried: row.mitigationTried ? JSON.parse(row.mitigationTried) : null,
-  });
+  return c.json(
+    {
+      ...row,
+      mitigationTried: row.mitigationTried ? JSON.parse(row.mitigationTried) : null,
+    },
+    200,
+  );
 });
 
 // PATCH /api/issue-reports/:id - 報告追記 (team_editor)
-app.patch(
-  '/issue-reports/:id',
-  setAuthContext,
-  zValidator('json', UpdateIssueReportSchema),
-  async (c) => {
-    const id = c.req.param('id')!;
-    const body = c.req.valid('json');
-    const authCtx = c.get('auth');
+const updateIssueReport = createRoute({
+  method: 'patch',
+  path: '/issue-reports/{id}',
+  tags: ['issue-reports'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: UpdateIssueReportSchema } }, required: true },
+  },
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: '報告更新' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(updateIssueReport, async (c) => {
+  const { id } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const authCtx = c.get('auth');
 
-    const existing = await db.query.issueReports.findFirst({ where: eq(issueReports.id, id) });
-    if (!existing) throw notFound('報告が見つかりません');
+  const existing = await db.query.issueReports.findFirst({ where: eq(issueReports.id, id) });
+  if (!existing) throw notFound('報告が見つかりません');
 
-    // 権限チェック: operator または当該チームの editor
-    if (authCtx?.userRole !== 'operator') {
-      if (
-        !authCtx?.teamId ||
-        authCtx.teamId !== existing.teamId ||
-        authCtx.teamAccessRole !== 'editor'
-      ) {
-        return c.json({ error: { code: 'FORBIDDEN', message: '報告の編集権限がありません' } }, 403);
-      }
+  // 権限チェック: operator または当該チームの editor
+  if (authCtx?.userRole !== 'operator') {
+    if (!authCtx?.userId && !authCtx?.teamId) {
+      throw unauthorized();
     }
+    if (
+      !authCtx?.teamId ||
+      authCtx.teamId !== existing.teamId ||
+      authCtx.teamAccessRole !== 'editor'
+    ) {
+      throw forbidden('報告の編集権限がありません');
+    }
+  }
 
-    const updateData = {
-      ...(() => {
-        const { mitigationTried: _m, ...rest } = body;
-        return rest;
-      })(),
-      updatedAt: new Date(),
-      ...(body.mitigationTried !== undefined && {
-        mitigationTried: JSON.stringify(body.mitigationTried),
-      }),
-    };
+  const updateData = {
+    ...(() => {
+      const { mitigationTried: _m, ...rest } = body;
+      return rest;
+    })(),
+    updatedAt: new Date(),
+    ...(body.mitigationTried !== undefined && {
+      mitigationTried: JSON.stringify(body.mitigationTried),
+    }),
+  };
 
-    const [row] = await db
-      .update(issueReports)
-      .set(updateData)
-      .where(eq(issueReports.id, id))
-      .returning();
-    if (!row) throw notFound('報告が見つかりません');
+  const [row] = await db
+    .update(issueReports)
+    .set(updateData)
+    .where(eq(issueReports.id, id))
+    .returning();
+  if (!row) throw notFound('報告が見つかりません');
 
-    return c.json({
+  return c.json(
+    {
       ...row,
       mitigationTried: row.mitigationTried ? JSON.parse(row.mitigationTried) : null,
-    });
-  },
-);
+    },
+    200,
+  );
+});
 
 export default app;

--- a/apps/api/src/routes/notices.ts
+++ b/apps/api/src/routes/notices.ts
@@ -1,47 +1,98 @@
-import { zValidator } from '@hono/zod-validator';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import { CreateNoticeSchema, UpdateNoticeSchema } from '@wifiman/shared';
 import { eq } from 'drizzle-orm';
-import { Hono } from 'hono';
+import type { ContextVariableMap } from 'hono';
 import { db } from '../db/index.js';
 import { notices } from '../db/schema/index.js';
 import { notFound } from '../errors.js';
 import { requireOperator } from '../middleware/auth.js';
 
-const app = new Hono();
+const app = new OpenAPIHono<{ Variables: ContextVariableMap }>();
+
+const errorSchema = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
 
 // GET /api/tournaments/:tournamentId/notices - お知らせ一覧 (public)
-app.get('/tournaments/:tournamentId/notices', async (c) => {
-  const { tournamentId } = c.req.param();
+const listNotices = createRoute({
+  method: 'get',
+  path: '/tournaments/{tournamentId}/notices',
+  tags: ['notices'],
+  request: { params: z.object({ tournamentId: z.string() }) },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(z.any()) } },
+      description: 'お知らせ一覧',
+    },
+  },
+});
+app.openapi(listNotices, async (c) => {
+  const { tournamentId } = c.req.valid('param');
   const rows = await db.select().from(notices).where(eq(notices.tournamentId, tournamentId));
-  return c.json(rows);
+  return c.json(rows, 200);
 });
 
 // POST /api/tournaments/:tournamentId/notices - お知らせ作成 (operator)
-app.post(
-  '/tournaments/:tournamentId/notices',
-  requireOperator,
-  zValidator('json', CreateNoticeSchema.omit({ tournamentId: true })),
-  async (c) => {
-    const { tournamentId } = c.req.param();
-    const body = c.req.valid('json');
-    const { publishedAt: publishedAtStr, expiresAt: expiresAtStr, ...restBody } = body;
-    const [row] = await db
-      .insert(notices)
-      .values({
-        ...restBody,
-        tournamentId,
-        publishedAt: new Date(publishedAtStr),
-        ...(expiresAtStr !== undefined ? { expiresAt: new Date(expiresAtStr) } : {}),
-      })
-      .returning();
-    if (!row) throw new Error('insert failed');
-    return c.json(row, 201);
+const createNotice = createRoute({
+  method: 'post',
+  path: '/tournaments/{tournamentId}/notices',
+  tags: ['notices'],
+  middleware: [requireOperator] as const,
+  request: {
+    params: z.object({ tournamentId: z.string() }),
+    body: {
+      content: { 'application/json': { schema: CreateNoticeSchema.omit({ tournamentId: true }) } },
+      required: true,
+    },
   },
-);
+  responses: {
+    201: { content: { 'application/json': { schema: z.any() } }, description: 'お知らせ作成' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+  },
+});
+app.openapi(createNotice, async (c) => {
+  const { tournamentId } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const { publishedAt: publishedAtStr, expiresAt: expiresAtStr, ...restBody } = body;
+  const [row] = await db
+    .insert(notices)
+    .values({
+      ...restBody,
+      tournamentId,
+      publishedAt: new Date(publishedAtStr),
+      ...(expiresAtStr !== undefined ? { expiresAt: new Date(expiresAtStr) } : {}),
+    })
+    .returning();
+  if (!row) throw new Error('insert failed');
+  return c.json(row, 201);
+});
 
 // PATCH /api/notices/:id - お知らせ更新 (operator)
-app.patch('/notices/:id', requireOperator, zValidator('json', UpdateNoticeSchema), async (c) => {
-  const id = c.req.param('id');
+const updateNotice = createRoute({
+  method: 'patch',
+  path: '/notices/{id}',
+  tags: ['notices'],
+  middleware: [requireOperator] as const,
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: UpdateNoticeSchema } }, required: true },
+  },
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: 'お知らせ更新' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(updateNotice, async (c) => {
+  const { id } = c.req.valid('param');
   const body = c.req.valid('json');
   const { publishedAt: publishedAtStr, expiresAt: expiresAtStr, ...restBody } = body;
   const updateData = {
@@ -51,7 +102,7 @@ app.patch('/notices/:id', requireOperator, zValidator('json', UpdateNoticeSchema
   };
   const [row] = await db.update(notices).set(updateData).where(eq(notices.id, id)).returning();
   if (!row) throw notFound('お知らせが見つかりません');
-  return c.json(row);
+  return c.json(row, 200);
 });
 
 export default app;

--- a/apps/api/src/routes/observedWifis.ts
+++ b/apps/api/src/routes/observedWifis.ts
@@ -1,94 +1,144 @@
-import { zValidator } from '@hono/zod-validator';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import {
   BulkCreateObservedWifiSchema,
   CreateObservedWifiSchema,
   isValidChannel,
 } from '@wifiman/shared';
 import { eq } from 'drizzle-orm';
-import { Hono } from 'hono';
+import type { ContextVariableMap } from 'hono';
 import { db } from '../db/index.js';
 import { observedWifis } from '../db/schema/index.js';
 import { validationError } from '../errors.js';
 import { requireOperator } from '../middleware/auth.js';
 
-const app = new Hono();
+const app = new OpenAPIHono<{ Variables: ContextVariableMap }>();
+
+const errorSchema = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
 
 // GET /api/tournaments/:tournamentId/observed-wifis - 野良 WiFi 一覧 (public)
-app.get('/tournaments/:tournamentId/observed-wifis', async (c) => {
-  const { tournamentId } = c.req.param();
+const listObservedWifis = createRoute({
+  method: 'get',
+  path: '/tournaments/{tournamentId}/observed-wifis',
+  tags: ['observed-wifis'],
+  request: { params: z.object({ tournamentId: z.string() }) },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(z.any()) } },
+      description: '野良 WiFi 一覧',
+    },
+  },
+});
+app.openapi(listObservedWifis, async (c) => {
+  const { tournamentId } = c.req.valid('param');
   const rows = await db
     .select()
     .from(observedWifis)
     .where(eq(observedWifis.tournamentId, tournamentId));
-  return c.json(rows);
+  return c.json(rows, 200);
 });
 
 // POST /api/tournaments/:tournamentId/observed-wifis - 野良 WiFi 手動登録 (operator)
-app.post(
-  '/tournaments/:tournamentId/observed-wifis',
-  requireOperator,
-  zValidator('json', CreateObservedWifiSchema.omit({ tournamentId: true })),
-  async (c) => {
-    const { tournamentId } = c.req.param();
-    const body = c.req.valid('json');
-
-    if (!isValidChannel(body.band, body.channel)) {
-      throw validationError(`帯域 ${body.band} に対してチャンネル ${body.channel} は無効です`);
-    }
-
-    const [row] = await db
-      .insert(observedWifis)
-      .values({
-        ...body,
-        tournamentId,
-        observedAt: new Date(body.observedAt),
-      })
-      .returning();
-    if (!row) throw new Error('insert failed');
-    return c.json(row, 201);
+const createObservedWifi = createRoute({
+  method: 'post',
+  path: '/tournaments/{tournamentId}/observed-wifis',
+  tags: ['observed-wifis'],
+  middleware: [requireOperator] as const,
+  request: {
+    params: z.object({ tournamentId: z.string() }),
+    body: {
+      content: {
+        'application/json': { schema: CreateObservedWifiSchema.omit({ tournamentId: true }) },
+      },
+      required: true,
+    },
   },
-);
+  responses: {
+    201: { content: { 'application/json': { schema: z.any() } }, description: '野良 WiFi 登録' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+  },
+});
+app.openapi(createObservedWifi, async (c) => {
+  const { tournamentId } = c.req.valid('param');
+  const body = c.req.valid('json');
+
+  if (!isValidChannel(body.band, body.channel)) {
+    throw validationError(`帯域 ${body.band} に対してチャンネル ${body.channel} は無効です`);
+  }
+
+  const [row] = await db
+    .insert(observedWifis)
+    .values({
+      ...body,
+      tournamentId,
+      observedAt: new Date(body.observedAt),
+    })
+    .returning();
+  if (!row) throw new Error('insert failed');
+  return c.json(row, 201);
+});
 
 // POST /api/tournaments/:tournamentId/observed-wifis/bulk - CSV 一括登録 (operator)
-app.post(
-  '/tournaments/:tournamentId/observed-wifis/bulk',
-  requireOperator,
-  zValidator('json', BulkCreateObservedWifiSchema),
-  async (c) => {
-    const { tournamentId } = c.req.param();
-    const { items } = c.req.valid('json');
-
-    // バリデーション: チャンネル・帯域の整合性確認
-    const errors: Array<{ row: number; message: string }> = [];
-    for (const [i, item] of items.entries()) {
-      if (!isValidChannel(item.band, item.channel)) {
-        errors.push({
-          row: i + 1,
-          message: `帯域 ${item.band} に対してチャンネル ${item.channel} は無効です`,
-        });
-      }
-    }
-
-    if (errors.length > 0) {
-      throw validationError('CSV に無効なデータが含まれています', { errors });
-    }
-
-    // トランザクション内で全件挿入
-    const inserted = await db.transaction(async (tx) => {
-      return tx
-        .insert(observedWifis)
-        .values(
-          items.map((item) => ({
-            ...item,
-            tournamentId,
-            observedAt: new Date(item.observedAt),
-          })),
-        )
-        .returning();
-    });
-
-    return c.json({ count: inserted.length, items: inserted }, 201);
+const bulkCreateObservedWifis = createRoute({
+  method: 'post',
+  path: '/tournaments/{tournamentId}/observed-wifis/bulk',
+  tags: ['observed-wifis'],
+  middleware: [requireOperator] as const,
+  request: {
+    params: z.object({ tournamentId: z.string() }),
+    body: {
+      content: { 'application/json': { schema: BulkCreateObservedWifiSchema } },
+      required: true,
+    },
   },
-);
+  responses: {
+    201: { content: { 'application/json': { schema: z.any() } }, description: '一括登録' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+  },
+});
+app.openapi(bulkCreateObservedWifis, async (c) => {
+  const { tournamentId } = c.req.valid('param');
+  const { items } = c.req.valid('json');
+
+  // バリデーション: チャンネル・帯域の整合性確認
+  const errors: Array<{ row: number; message: string }> = [];
+  for (const [i, item] of items.entries()) {
+    if (!isValidChannel(item.band, item.channel)) {
+      errors.push({
+        row: i + 1,
+        message: `帯域 ${item.band} に対してチャンネル ${item.channel} は無効です`,
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    throw validationError('CSV に無効なデータが含まれています', { errors });
+  }
+
+  // トランザクション内で全件挿入
+  const inserted = await db.transaction(async (tx) => {
+    return tx
+      .insert(observedWifis)
+      .values(
+        items.map((item) => ({
+          ...item,
+          tournamentId,
+          observedAt: new Date(item.observedAt),
+        })),
+      )
+      .returning();
+  });
+
+  return c.json({ count: inserted.length, items: inserted }, 201);
+});
 
 export default app;

--- a/apps/api/src/routes/teamAccesses.ts
+++ b/apps/api/src/routes/teamAccesses.ts
@@ -1,4 +1,4 @@
-import { zValidator } from '@hono/zod-validator';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import {
   CreateTeamAccessSchema,
   generateAccessToken,
@@ -8,7 +8,7 @@ import {
   verifyAccessToken,
 } from '@wifiman/shared';
 import { eq } from 'drizzle-orm';
-import { Hono } from 'hono';
+import type { ContextVariableMap } from 'hono';
 import { setCookie } from 'hono/cookie';
 import { db } from '../db/index.js';
 import { teamAccesses } from '../db/schema/index.js';
@@ -17,63 +17,116 @@ import { notFound, unauthorized } from '../errors.js';
 import { createMailer } from '../mailer/index.js';
 import { requireOperator } from '../middleware/auth.js';
 
-const app = new Hono();
+const app = new OpenAPIHono<{ Variables: ContextVariableMap }>();
+
+const errorSchema = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
 
 // POST /api/teams/:teamId/team-accesses - 編集リンク発行 (operator)
-app.post(
-  '/teams/:teamId/team-accesses',
-  requireOperator,
-  zValidator('json', CreateTeamAccessSchema.omit({ teamId: true })),
-  async (c) => {
-    const teamId = c.req.param('teamId');
-    const body = c.req.valid('json');
-
-    const token = generateAccessToken();
-    const hash = hashAccessToken(token);
-
-    const [access] = await db
-      .insert(teamAccesses)
-      .values({
-        teamId,
-        email: body.email,
-        accessTokenHash: hash,
-        role: body.role,
-      })
-      .returning();
-    if (!access) throw new Error('insert failed');
-
-    // メール送信 (失敗してもエラーにしない: ログのみ)
-    const link = `${env.APP_ORIGIN}/team-access?token=${token}&id=${access.id}`;
-    try {
-      const mailer = createMailer();
-      if (mailer) {
-        await mailer.sendTeamAccessLink(body.email, teamId, link);
-      }
-    } catch (err) {
-      console.error('チーム編集リンク送信失敗:', err);
-    }
-
-    return c.json(
-      { id: access.id, teamId: access.teamId, email: access.email, role: access.role, link },
-      201,
-    );
+const createTeamAccess = createRoute({
+  method: 'post',
+  path: '/teams/{teamId}/team-accesses',
+  tags: ['team-accesses'],
+  middleware: [requireOperator] as const,
+  request: {
+    params: z.object({ teamId: z.string() }),
+    body: {
+      content: {
+        'application/json': { schema: CreateTeamAccessSchema.omit({ teamId: true }) },
+      },
+      required: true,
+    },
   },
-);
+  responses: {
+    201: { content: { 'application/json': { schema: z.any() } }, description: '編集リンク発行' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+  },
+});
+app.openapi(createTeamAccess, async (c) => {
+  const { teamId } = c.req.valid('param');
+  const body = c.req.valid('json');
+
+  const token = generateAccessToken();
+  const hash = hashAccessToken(token);
+
+  const [access] = await db
+    .insert(teamAccesses)
+    .values({
+      teamId,
+      email: body.email,
+      accessTokenHash: hash,
+      role: body.role,
+    })
+    .returning();
+  if (!access) throw new Error('insert failed');
+
+  // メール送信 (失敗してもエラーにしない: ログのみ)
+  const link = `${env.APP_ORIGIN}/team-access?token=${token}&id=${access.id}`;
+  try {
+    const mailer = createMailer();
+    if (mailer) {
+      await mailer.sendTeamAccessLink(body.email, teamId, link);
+    }
+  } catch (err) {
+    console.error('チーム編集リンク送信失敗:', err);
+  }
+
+  return c.json(
+    { id: access.id, teamId: access.teamId, email: access.email, role: access.role, link },
+    201,
+  );
+});
 
 // POST /api/team-accesses/:id/revoke - 編集リンク失効 (operator)
-app.post('/team-accesses/:id/revoke', requireOperator, async (c) => {
-  const id = c.req.param('id')!;
+const revokeTeamAccess = createRoute({
+  method: 'post',
+  path: '/team-accesses/{id}/revoke',
+  tags: ['team-accesses'],
+  middleware: [requireOperator] as const,
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: '失効成功' },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(revokeTeamAccess, async (c) => {
+  const { id } = c.req.valid('param');
   const [row] = await db
     .update(teamAccesses)
     .set({ revokedAt: new Date(), updatedAt: new Date() })
     .where(eq(teamAccesses.id, id))
     .returning();
   if (!row) throw notFound('チームアクセストークンが見つかりません');
-  return c.json({ message: '失効しました' });
+  return c.json({ message: '失効しました' }, 200);
 });
 
-// POST /api/auth/team-link - チーム編集リンク認証 (public)
-app.post('/auth/team-link', zValidator('json', VerifyTeamLinkSchema), async (c) => {
+// POST /api/team-accesses/verify - チーム編集リンク認証 (public)
+const verifyTeamLink = createRoute({
+  method: 'post',
+  path: '/team-accesses/verify',
+  tags: ['auth'],
+  request: {
+    body: { content: { 'application/json': { schema: VerifyTeamLinkSchema } }, required: true },
+  },
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: '認証成功' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: '無効なトークン',
+    },
+  },
+});
+app.openapi(verifyTeamLink, async (c) => {
   const { token } = c.req.valid('json');
 
   // トークンの前半16文字からアクセスIDを探す (全件スキャン回避のためハッシュで検索)
@@ -104,7 +157,7 @@ app.post('/auth/team-link', zValidator('json', VerifyTeamLinkSchema), async (c) 
   setCookie(c, 'team_access_token', token, cookieOptions);
   setCookie(c, 'team_access_id', access.id, cookieOptions);
 
-  return c.json({ teamId: access.teamId, role: access.role });
+  return c.json({ teamId: access.teamId, role: access.role }, 200);
 });
 
 export default app;

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -1,69 +1,129 @@
-import { zValidator } from '@hono/zod-validator';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import { CreateTeamSchema, UpdateTeamSchema } from '@wifiman/shared';
 import { eq } from 'drizzle-orm';
-import { Hono } from 'hono';
+import type { ContextVariableMap } from 'hono';
 import { db } from '../db/index.js';
 import { teams } from '../db/schema/index.js';
 import { conflict, notFound } from '../errors.js';
 import { requireOperator, requireTeamEditor, requireTeamViewer } from '../middleware/auth.js';
 
-const app = new Hono();
+const app = new OpenAPIHono<{ Variables: ContextVariableMap }>();
+
+const errorSchema = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
 
 // GET /api/tournaments/:tournamentId/teams - チーム一覧 (public)
-app.get('/tournaments/:tournamentId/teams', async (c) => {
-  const { tournamentId } = c.req.param();
+const listTeams = createRoute({
+  method: 'get',
+  path: '/tournaments/{tournamentId}/teams',
+  tags: ['teams'],
+  request: { params: z.object({ tournamentId: z.string() }) },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(z.any()) } },
+      description: 'チーム一覧',
+    },
+  },
+});
+app.openapi(listTeams, async (c) => {
+  const { tournamentId } = c.req.valid('param');
   const rows = await db.select().from(teams).where(eq(teams.tournamentId, tournamentId));
-  return c.json(rows);
+  return c.json(rows, 200);
 });
 
 // POST /api/tournaments/:tournamentId/teams - チーム作成 (operator)
-app.post(
-  '/tournaments/:tournamentId/teams',
-  requireOperator,
-  zValidator('json', CreateTeamSchema.omit({ tournamentId: true })),
-  async (c) => {
-    const { tournamentId } = c.req.param();
-    const body = c.req.valid('json');
-    try {
-      const [row] = await db
-        .insert(teams)
-        .values({ ...body, tournamentId })
-        .returning();
-      if (!row) throw new Error('insert failed');
-      return c.json(row, 201);
-    } catch (err) {
-      if (err instanceof Error && err.message.includes('teams_tournament_name_unique')) {
-        throw conflict('同じ大会にすでに同名のチームが存在します');
-      }
-      throw err;
-    }
+const createTeam = createRoute({
+  method: 'post',
+  path: '/tournaments/{tournamentId}/teams',
+  tags: ['teams'],
+  middleware: [requireOperator] as const,
+  request: {
+    params: z.object({ tournamentId: z.string() }),
+    body: {
+      content: { 'application/json': { schema: CreateTeamSchema.omit({ tournamentId: true }) } },
+      required: true,
+    },
   },
-);
+  responses: {
+    201: { content: { 'application/json': { schema: z.any() } }, description: 'チーム作成' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    409: { content: { 'application/json': { schema: errorSchema } }, description: '競合' },
+  },
+});
+app.openapi(createTeam, async (c) => {
+  const { tournamentId } = c.req.valid('param');
+  const body = c.req.valid('json');
+  try {
+    const [row] = await db
+      .insert(teams)
+      .values({ ...body, tournamentId })
+      .returning();
+    if (!row) throw new Error('insert failed');
+    return c.json(row, 201);
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('teams_tournament_name_unique')) {
+      throw conflict('同じ大会にすでに同名のチームが存在します');
+    }
+    throw err;
+  }
+});
 
 // GET /api/teams/:id - チーム詳細 (team_viewer)
-app.get('/teams/:teamId', requireTeamViewer('teamId'), async (c) => {
-  const id = c.req.param('teamId')!;
-  const row = await db.query.teams.findFirst({ where: eq(teams.id, id) });
+const getTeam = createRoute({
+  method: 'get',
+  path: '/teams/{teamId}',
+  tags: ['teams'],
+  middleware: [requireTeamViewer('teamId')] as const,
+  request: { params: z.object({ teamId: z.string() }) },
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: 'チーム詳細' },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(getTeam, async (c) => {
+  const { teamId } = c.req.valid('param');
+  const row = await db.query.teams.findFirst({ where: eq(teams.id, teamId) });
   if (!row) throw notFound('チームが見つかりません');
-  return c.json(row);
+  return c.json(row, 200);
 });
 
 // PATCH /api/teams/:id - チーム更新 (team_editor)
-app.patch(
-  '/teams/:teamId',
-  requireTeamEditor('teamId'),
-  zValidator('json', UpdateTeamSchema),
-  async (c) => {
-    const id = c.req.param('teamId')!;
-    const body = c.req.valid('json');
-    const [row] = await db
-      .update(teams)
-      .set({ ...body, updatedAt: new Date() })
-      .where(eq(teams.id, id))
-      .returning();
-    if (!row) throw notFound('チームが見つかりません');
-    return c.json(row);
+const updateTeam = createRoute({
+  method: 'patch',
+  path: '/teams/{teamId}',
+  tags: ['teams'],
+  middleware: [requireTeamEditor('teamId')] as const,
+  request: {
+    params: z.object({ teamId: z.string() }),
+    body: { content: { 'application/json': { schema: UpdateTeamSchema } }, required: true },
   },
-);
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: 'チーム更新' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(updateTeam, async (c) => {
+  const { teamId } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const [row] = await db
+    .update(teams)
+    .set({ ...body, updatedAt: new Date() })
+    .where(eq(teams.id, teamId))
+    .returning();
+  if (!row) throw notFound('チームが見つかりません');
+  return c.json(row, 200);
+});
 
 export default app;

--- a/apps/api/src/routes/tournaments.ts
+++ b/apps/api/src/routes/tournaments.ts
@@ -1,22 +1,51 @@
-import { zValidator } from '@hono/zod-validator';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import { CreateTournamentSchema, UpdateTournamentSchema } from '@wifiman/shared';
 import { eq } from 'drizzle-orm';
-import { Hono } from 'hono';
+import type { ContextVariableMap } from 'hono';
 import { db } from '../db/index.js';
 import { tournaments } from '../db/schema/index.js';
 import { notFound } from '../errors.js';
 import { requireOperator } from '../middleware/auth.js';
 
-const app = new Hono();
+const app = new OpenAPIHono<{ Variables: ContextVariableMap }>();
+
+const errorSchema = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
+const idParam = z.object({ id: z.string() });
 
 // GET /api/tournaments - 大会一覧 (public)
-app.get('/', async (c) => {
+const listTournaments = createRoute({
+  method: 'get',
+  path: '/tournaments',
+  tags: ['tournaments'],
+  responses: {
+    200: { content: { 'application/json': { schema: z.array(z.any()) } }, description: '大会一覧' },
+  },
+});
+app.openapi(listTournaments, async (c) => {
   const rows = await db.select().from(tournaments).orderBy(tournaments.startDate);
-  return c.json(rows);
+  return c.json(rows, 200);
 });
 
 // POST /api/tournaments - 大会作成 (operator)
-app.post('/', requireOperator, zValidator('json', CreateTournamentSchema), async (c) => {
+const createTournament = createRoute({
+  method: 'post',
+  path: '/tournaments',
+  tags: ['tournaments'],
+  middleware: [requireOperator] as const,
+  request: {
+    body: { content: { 'application/json': { schema: CreateTournamentSchema } }, required: true },
+  },
+  responses: {
+    201: { content: { 'application/json': { schema: z.any() } }, description: '大会作成' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+  },
+});
+app.openapi(createTournament, async (c) => {
   const body = c.req.valid('json');
   const [row] = await db
     .insert(tournaments)
@@ -33,16 +62,46 @@ app.post('/', requireOperator, zValidator('json', CreateTournamentSchema), async
 });
 
 // GET /api/tournaments/:id - 大会詳細 (public)
-app.get('/:id', async (c) => {
-  const id = c.req.param('id');
+const getTournament = createRoute({
+  method: 'get',
+  path: '/tournaments/{id}',
+  tags: ['tournaments'],
+  request: { params: idParam },
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: '大会詳細' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(getTournament, async (c) => {
+  const { id } = c.req.valid('param');
   const row = await db.query.tournaments.findFirst({ where: eq(tournaments.id, id) });
   if (!row) throw notFound('大会が見つかりません');
-  return c.json(row);
+  return c.json(row, 200);
 });
 
 // PATCH /api/tournaments/:id - 大会更新 (operator)
-app.patch('/:id', requireOperator, zValidator('json', UpdateTournamentSchema), async (c) => {
-  const id = c.req.param('id');
+const updateTournament = createRoute({
+  method: 'patch',
+  path: '/tournaments/{id}',
+  tags: ['tournaments'],
+  middleware: [requireOperator] as const,
+  request: {
+    params: idParam,
+    body: { content: { 'application/json': { schema: UpdateTournamentSchema } }, required: true },
+  },
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: '大会更新' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+  },
+});
+app.openapi(updateTournament, async (c) => {
+  const { id } = c.req.valid('param');
   const body = c.req.valid('json');
   const [row] = await db
     .update(tournaments)
@@ -50,7 +109,7 @@ app.patch('/:id', requireOperator, zValidator('json', UpdateTournamentSchema), a
     .where(eq(tournaments.id, id))
     .returning();
   if (!row) throw notFound('大会が見つかりません');
-  return c.json(row);
+  return c.json(row, 200);
 });
 
 export default app;

--- a/apps/api/src/routes/wifiConfigs.ts
+++ b/apps/api/src/routes/wifiConfigs.ts
@@ -1,5 +1,5 @@
-import { zValidator } from '@hono/zod-validator';
-import type { ChannelWidth, WifiConfigStatus } from '@wifiman/shared';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
+import type { Band, ChannelWidth, WifiConfigStatus } from '@wifiman/shared';
 import {
   CreateWifiConfigSchema,
   canActivateWifiConfig,
@@ -9,143 +9,187 @@ import {
   UpdateWifiConfigSchema,
 } from '@wifiman/shared';
 import { eq } from 'drizzle-orm';
-import { Hono } from 'hono';
+import type { ContextVariableMap, MiddlewareHandler } from 'hono';
 import { db } from '../db/index.js';
 import { wifiConfigs } from '../db/schema/index.js';
 import { notFound, unprocessable } from '../errors.js';
 import { requireTeamEditor, requireTeamViewer } from '../middleware/auth.js';
 
-const app = new Hono();
+const app = new OpenAPIHono<{ Variables: ContextVariableMap }>();
 
-function validateChannelAndWidth(
-  band: 'band_placeholder' | '2.4GHz' | '5GHz' | '6GHz',
-  channel: number,
-  widthMHz: number,
-) {
-  const b = band as '2.4GHz' | '5GHz' | '6GHz';
-  if (!isValidChannel(b, channel)) {
+const errorSchema = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
+type AppMiddleware = MiddlewareHandler<{ Variables: ContextVariableMap }>;
+
+const resolveWifiConfigTeamMiddleware: AppMiddleware = async (c, next) => {
+  const id = c.req.param('id') as string;
+  const config = await db.query.wifiConfigs.findFirst({ where: eq(wifiConfigs.id, id) });
+  if (!config) throw notFound('WiFi 構成が見つかりません');
+  c.set('_targetTeamId', config.teamId);
+  await next();
+};
+
+function validateChannelAndWidth(band: Band, channel: number, widthMHz: number) {
+  if (!isValidChannel(band, channel)) {
     throw unprocessable(`帯域 ${band} に対してチャンネル ${channel} は無効です`);
   }
-  if (!isValidChannelWidth(b, widthMHz as ChannelWidth)) {
+  if (!isValidChannelWidth(band, widthMHz as ChannelWidth)) {
     throw unprocessable(`帯域 ${band} に対してチャンネル幅 ${widthMHz}MHz は無効です`);
   }
 }
 
 // GET /api/teams/:teamId/wifi-configs - WiFi 構成一覧 (team_viewer)
-app.get('/teams/:teamId/wifi-configs', requireTeamViewer('teamId'), async (c) => {
-  const teamId = c.req.param('teamId')!;
+const listWifiConfigs = createRoute({
+  method: 'get',
+  path: '/teams/{teamId}/wifi-configs',
+  tags: ['wifi-configs'],
+  middleware: [requireTeamViewer('teamId')] as const,
+  request: { params: z.object({ teamId: z.string() }) },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(z.any()) } },
+      description: 'WiFi 構成一覧',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+  },
+});
+app.openapi(listWifiConfigs, async (c) => {
+  const { teamId } = c.req.valid('param');
   const rows = await db.select().from(wifiConfigs).where(eq(wifiConfigs.teamId, teamId));
-  return c.json(rows);
+  return c.json(rows, 200);
 });
 
 // POST /api/teams/:teamId/wifi-configs - WiFi 構成作成 (team_editor)
-app.post(
-  '/teams/:teamId/wifi-configs',
-  requireTeamEditor('teamId'),
-  zValidator('json', CreateWifiConfigSchema.omit({ teamId: true })),
-  async (c) => {
-    const teamId = c.req.param('teamId')!;
-    const body = c.req.valid('json');
-
-    // チャンネル・幅の検証
-    validateChannelAndWidth(body.band, body.channel, body.channelWidthMHz);
-
-    // 3 件上限チェック (active + standby のみカウント)
-    if (body.status !== 'disabled') {
-      const existing = await db
-        .select({ status: wifiConfigs.status })
-        .from(wifiConfigs)
-        .where(eq(wifiConfigs.teamId, teamId));
-      if (!canAddWifiConfig(existing)) {
-        throw unprocessable('WiFi 構成は最大 3 件 (active + standby) までです');
-      }
-    }
-
-    const [row] = await db
-      .insert(wifiConfigs)
-      .values({ ...body, teamId })
-      .returning();
-    if (!row) throw new Error('insert failed');
-    return c.json(row, 201);
+const createWifiConfig = createRoute({
+  method: 'post',
+  path: '/teams/{teamId}/wifi-configs',
+  tags: ['wifi-configs'],
+  middleware: [requireTeamEditor('teamId')] as const,
+  request: {
+    params: z.object({ teamId: z.string() }),
+    body: {
+      content: { 'application/json': { schema: CreateWifiConfigSchema.omit({ teamId: true }) } },
+      required: true,
+    },
   },
-);
+  responses: {
+    201: { content: { 'application/json': { schema: z.any() } }, description: 'WiFi 構成作成' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    422: { content: { 'application/json': { schema: errorSchema } }, description: '処理不能' },
+  },
+});
+app.openapi(createWifiConfig, async (c) => {
+  const { teamId } = c.req.valid('param');
+  const body = c.req.valid('json');
+
+  // チャンネル・幅の検証
+  validateChannelAndWidth(body.band, body.channel, body.channelWidthMHz);
+
+  // 3 件上限チェック (active + standby のみカウント)
+  if (body.status !== 'disabled') {
+    const existing = await db
+      .select({ status: wifiConfigs.status })
+      .from(wifiConfigs)
+      .where(eq(wifiConfigs.teamId, teamId));
+    if (!canAddWifiConfig(existing)) {
+      throw unprocessable('WiFi 構成は最大 3 件 (active + standby) までです');
+    }
+  }
+
+  const [row] = await db
+    .insert(wifiConfigs)
+    .values({ ...body, teamId })
+    .returning();
+  if (!row) throw new Error('insert failed');
+  return c.json(row, 201);
+});
 
 // PATCH /api/wifi-configs/:id - WiFi 構成更新 (team_editor)
-app.patch(
-  '/wifi-configs/:id',
-  async (c, next) => {
-    // teamId を wifiConfigs から取得して team_editor チェックに使う
-    const id = c.req.param('id')!;
-    const config = await db.query.wifiConfigs.findFirst({ where: eq(wifiConfigs.id, id) });
-    if (!config) throw notFound('WiFi 構成が見つかりません');
-    // teamId を param として上書き (ミドルウェアが c.req.param('teamId') を期待するため)
-    c.set('_targetTeamId', config.teamId);
-    await next();
+const patchWifiConfig = createRoute({
+  method: 'patch',
+  path: '/wifi-configs/{id}',
+  tags: ['wifi-configs'],
+  middleware: [resolveWifiConfigTeamMiddleware, requireTeamEditor('teamId')] as const,
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: UpdateWifiConfigSchema } }, required: true },
   },
-  requireTeamEditor('teamId'),
-  zValidator('json', UpdateWifiConfigSchema),
-  async (c) => {
-    const id = c.req.param('id')!;
-    const body = c.req.valid('json');
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: 'WiFi 構成更新' },
+    400: {
+      content: { 'application/json': { schema: errorSchema } },
+      description: 'バリデーションエラー',
+    },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
+    422: { content: { 'application/json': { schema: errorSchema } }, description: '処理不能' },
+  },
+});
+app.openapi(patchWifiConfig, async (c) => {
+  const { id } = c.req.valid('param');
+  const body = c.req.valid('json');
 
-    const existing = await db.query.wifiConfigs.findFirst({ where: eq(wifiConfigs.id, id) });
-    if (!existing) throw notFound('WiFi 構成が見つかりません');
+  const existing = await db.query.wifiConfigs.findFirst({ where: eq(wifiConfigs.id, id) });
+  if (!existing) throw notFound('WiFi 構成が見つかりません');
 
-    const newBand = body.band ?? existing.band;
-    const newChannel = body.channel ?? existing.channel;
-    const newWidth = body.channelWidthMHz ?? existing.channelWidthMHz;
+  const newBand = body.band ?? existing.band;
+  const newChannel = body.channel ?? existing.channel;
+  const newWidth = body.channelWidthMHz ?? existing.channelWidthMHz;
 
+  if (body.band !== undefined || body.channel !== undefined || body.channelWidthMHz !== undefined) {
+    validateChannelAndWidth(newBand, newChannel, newWidth);
+  }
+
+  // ステータス変更時の上限チェック
+  if (body.status !== undefined && body.status !== 'disabled') {
+    const allConfigs = await db
+      .select({ status: wifiConfigs.status, id: wifiConfigs.id })
+      .from(wifiConfigs)
+      .where(eq(wifiConfigs.teamId, existing.teamId));
     if (
-      body.band !== undefined ||
-      body.channel !== undefined ||
-      body.channelWidthMHz !== undefined
+      !canActivateWifiConfig(
+        allConfigs as Array<{ id: string; status: WifiConfigStatus }>,
+        id,
+        body.status,
+      )
     ) {
-      validateChannelAndWidth(newBand, newChannel, newWidth);
+      throw unprocessable('WiFi 構成は最大 3 件 (active + standby) までです');
     }
+  }
 
-    // ステータス変更時の上限チェック
-    if (body.status !== undefined && body.status !== 'disabled') {
-      const allConfigs = await db
-        .select({ status: wifiConfigs.status, id: wifiConfigs.id })
-        .from(wifiConfigs)
-        .where(eq(wifiConfigs.teamId, existing.teamId));
-      if (
-        !canActivateWifiConfig(
-          allConfigs as Array<{ id: string; status: WifiConfigStatus }>,
-          id,
-          body.status,
-        )
-      ) {
-        throw unprocessable('WiFi 構成は最大 3 件 (active + standby) までです');
-      }
-    }
-
-    const [row] = await db
-      .update(wifiConfigs)
-      .set({ ...body, updatedAt: new Date() })
-      .where(eq(wifiConfigs.id, id))
-      .returning();
-    if (!row) throw notFound('WiFi 構成が見つかりません');
-    return c.json(row);
-  },
-);
+  const [row] = await db
+    .update(wifiConfigs)
+    .set({ ...body, updatedAt: new Date() })
+    .where(eq(wifiConfigs.id, id))
+    .returning();
+  if (!row) throw notFound('WiFi 構成が見つかりません');
+  return c.json(row, 200);
+});
 
 // DELETE /api/wifi-configs/:id - WiFi 構成削除 (team_editor)
-app.delete(
-  '/wifi-configs/:id',
-  async (c, next) => {
-    const id = c.req.param('id')!;
-    const config = await db.query.wifiConfigs.findFirst({ where: eq(wifiConfigs.id, id) });
-    if (!config) throw notFound('WiFi 構成が見つかりません');
-    c.set('_targetTeamId', config.teamId);
-    await next();
+const deleteWifiConfig = createRoute({
+  method: 'delete',
+  path: '/wifi-configs/{id}',
+  tags: ['wifi-configs'],
+  middleware: [resolveWifiConfigTeamMiddleware, requireTeamEditor('teamId')] as const,
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { content: { 'application/json': { schema: z.any() } }, description: '削除成功' },
+    401: { content: { 'application/json': { schema: errorSchema } }, description: '未認証' },
+    403: { content: { 'application/json': { schema: errorSchema } }, description: '権限なし' },
+    404: { content: { 'application/json': { schema: errorSchema } }, description: 'Not Found' },
   },
-  requireTeamEditor('teamId'),
-  async (c) => {
-    const id = c.req.param('id')!;
-    await db.delete(wifiConfigs).where(eq(wifiConfigs.id, id));
-    return c.json({ message: '削除しました' });
-  },
-);
+});
+app.openapi(deleteWifiConfig, async (c) => {
+  const { id } = c.req.valid('param');
+  await db.delete(wifiConfigs).where(eq(wifiConfigs.id, id));
+  return c.json({ message: '削除しました' }, 200);
+});
 
 export default app;

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "dev": "pnpm --filter @wifiman/api dev",
+    "dev": "dotenv -- pnpm --filter @wifiman/api dev",
     "build": "pnpm -r build",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
@@ -16,5 +16,8 @@
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "dotenv-cli": "^11.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      dotenv-cli:
+        specifier: ^11.0.0
+        version: 11.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.0.0
@@ -1007,6 +1011,10 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1022,6 +1030,22 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  dotenv-cli@11.0.0:
+    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
+    hasBin: true
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -1165,6 +1189,9 @@ packages:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
@@ -1180,6 +1207,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1199,6 +1229,10 @@ packages:
 
   openapi3-ts@4.5.0:
     resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1235,6 +1269,14 @@ packages:
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1366,6 +1408,11 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -1932,6 +1979,12 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -1939,6 +1992,21 @@ snapshots:
   deep-eql@5.0.2: {}
 
   defu@6.1.7: {}
+
+  dotenv-cli@11.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 17.4.2
+      dotenv-expand: 12.0.3
+      minimist: 1.2.8
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.1
+
+  dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
 
   drizzle-kit@0.31.10:
     dependencies:
@@ -2057,6 +2125,8 @@ snapshots:
 
   hono@4.12.14: {}
 
+  isexe@2.0.0: {}
+
   jose@6.2.2: {}
 
   js-tokens@9.0.1: {}
@@ -2069,6 +2139,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  minimist@1.2.8: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -2080,6 +2152,8 @@ snapshots:
   openapi3-ts@4.5.0:
     dependencies:
       yaml: 2.8.3
+
+  path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
@@ -2133,6 +2207,12 @@ snapshots:
   rou3@0.7.12: {}
 
   set-cookie-parser@3.1.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
 
@@ -2254,6 +2334,10 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,15 +20,18 @@ importers:
       '@hono/node-server':
         specifier: ^1.14.4
         version: 1.19.14(hono@4.12.14)
-      '@hono/zod-validator':
-        specifier: ^0.4.3
-        version: 0.4.3(hono@4.12.14)(zod@3.25.76)
+      '@hono/swagger-ui':
+        specifier: ^0.6.1
+        version: 0.6.1(hono@4.12.14)
+      '@hono/zod-openapi':
+        specifier: ^0.19.10
+        version: 0.19.10(hono@4.12.14)(zod@3.25.76)
       '@wifiman/shared':
         specifier: workspace:*
         version: link:../../packages/shared
       better-auth:
         specifier: ^1.6.5
-        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0))
+        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9)
@@ -68,7 +71,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.3
-        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/config: {}
 
@@ -89,9 +92,14 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.3
-        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
+
+  '@asteasolutions/zod-to-openapi@7.3.4':
+    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@better-auth/core@1.6.5':
     resolution: {integrity: sha512-T3u4rVsJcMWShG2qfQUlU1HdkQGLYX0+lcR48QV2Cp2kpBOLOTYdt+p6zZtGm2Omx/ReEouRQyKy7pYtahRQuA==}
@@ -688,11 +696,23 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/zod-validator@0.4.3':
-    resolution: {integrity: sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==}
+  '@hono/swagger-ui@0.6.1':
+    resolution: {integrity: sha512-sJTvldu1GPeEPfyeLG7gRj+W4vEuD+JDi+JjJ3TJs/DvMUtBLs0KJO5yokGegWWdy5qrbdnQGekbhgNRmPmYKQ==}
+    peerDependencies:
+      hono: '>=4.0.0'
+
+  '@hono/zod-openapi@0.19.10':
+    resolution: {integrity: sha512-dpoS6DenvoJyvxtQ7Kd633FRZ/Qf74+4+o9s+zZI8pEqnbjdF/DtxIib08WDpCaWabMEJOL5TXpMgNEZvb7hpA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: '>=3.0.0'
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
     peerDependencies:
       hono: '>=3.9.0'
-      zod: ^3.19.1
+      zod: ^3.25.0 || ^4.0.0
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1177,6 +1197,9 @@ packages:
     resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
     engines: {node: '>=6.0.0'}
 
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1349,6 +1372,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -1356,6 +1384,11 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
 
   '@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)':
     dependencies:
@@ -1684,7 +1717,19 @@ snapshots:
     dependencies:
       hono: 4.12.14
 
-  '@hono/zod-validator@0.4.3(hono@4.12.14)(zod@3.25.76)':
+  '@hono/swagger-ui@0.6.1(hono@4.12.14)':
+    dependencies:
+      hono: 4.12.14
+
+  '@hono/zod-openapi@0.19.10(hono@4.12.14)(zod@3.25.76)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.76)
+      '@hono/zod-validator': 0.7.6(hono@4.12.14)(zod@3.25.76)
+      hono: 4.12.14
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
+
+  '@hono/zod-validator@0.7.6(hono@4.12.14)(zod@3.25.76)':
     dependencies:
       hono: 4.12.14
       zod: 3.25.76
@@ -1801,13 +1846,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1837,7 +1882,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)):
+  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))
@@ -1859,7 +1904,7 @@ snapshots:
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9)
-      vitest: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+      vitest: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -2032,6 +2077,10 @@ snapshots:
 
   nodemailer@6.10.1: {}
 
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.3
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -2130,13 +2179,13 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  vite-node@3.2.4(@types/node@22.19.17)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2151,7 +2200,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0):
+  vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2163,12 +2212,13 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2186,8 +2236,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -2209,6 +2259,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yaml@2.8.3: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## 概要

Issue #3 の実装。`@hono/zod-validator` を廃止し `@hono/zod-openapi` に移行することで、Zod スキーマを唯一の信頼源としてリクエスト/レスポンスのバリデーションと OpenAPI 3.1 ドキュメントを同時に生成できるようにした。

Closes #3

---

## 主要変更点

### 依存関係
| 操作 | パッケージ |
|---|---|
| 追加 | \`@hono/zod-openapi@^0.19.10\` |
| 追加 | \`@hono/swagger-ui@^0.6.1\` |
| 削除 | \`@hono/zod-validator\` |

### \`apps/api/src/app.ts\`
- \`Hono\` → \`OpenAPIHono<{ Variables: ContextVariableMap }>\` に変更
- \`api\` サブルーターも \`OpenAPIHono\` に変更
- \`GET /api/docs\` — Swagger UI エンドポイントを追加
- \`GET /api/openapi.json\` — OpenAPI 3.1 スキーマエンドポイントを追加

### ルートファイル（9 ファイル共通）
- \`import { Hono }\` → \`import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'\` に変更
- \`app.get/post/patch/delete()\` → \`createRoute\` + \`app.openapi()\` 形式に変換
- \`zValidator('json', schema)\` を \`createRoute\` の \`request.body\` スキーマに移動
- パスパラメータを \`request.params\` で型安全（\`c.req.valid('param')\`）に取得
- 各エンドポイントに OpenAPI タグ・成功/エラーレスポンス定義を追加

対象ファイル: \`tournaments.ts\` / \`teams.ts\` / \`teamAccesses.ts\` / \`wifiConfigs.ts\` / \`deviceSpecs.ts\` / \`observedWifis.ts\` / \`issueReports.ts\` / \`bestPractices.ts\` / \`notices.ts\`

---

## 破壊的変更

**なし。** \`app.ts\` で \`tournaments\` のマウント先を \`/tournaments\` → \`/\` に変更したが、各ルートの \`createRoute\` 内で \`/tournaments\` パスを定義しているため、外部から見た API パスは変わらない。

---

## テスト結果

| チェック | 結果 |
|---|---|
| \`pnpm typecheck\` | ✅ エラーなし |
| \`pnpm lint\` | ✅ エラーなし |
| \`pnpm test\` | ✅ 70 passed (shared: 61, api: 9) |