### PR TITLE
test(api): migrate teams route tests to pglite and extend coverage

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "zod": "^3.25.17"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.4.4",
     "@types/node": "^22.15.3",
     "@types/nodemailer": "^6.4.17",
     "@wifiman/config": "workspace:*",

--- a/apps/api/src/routes/teamErrors.ts
+++ b/apps/api/src/routes/teamErrors.ts
@@ -2,14 +2,20 @@ type PostgresErrorLike = {
   code?: string;
   constraint_name?: string;
   constraint?: string;
+  cause?: unknown;
 };
 
 export function isTeamsNameUniqueViolation(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   const pgError = err as PostgresErrorLike;
-  if (pgError.code !== '23505') return false;
+  const candidate =
+    pgError.code === '23505'
+      ? pgError
+      : ((pgError.cause as PostgresErrorLike | undefined) ?? pgError);
+  if (!candidate || typeof candidate !== 'object') return false;
+  if (candidate.code !== '23505') return false;
   return (
-    pgError.constraint_name === 'teams_tournament_name_unique' ||
-    pgError.constraint === 'teams_tournament_name_unique'
+    candidate.constraint_name === 'teams_tournament_name_unique' ||
+    candidate.constraint === 'teams_tournament_name_unique'
   );
 }

--- a/apps/api/tests/integration/helpers/testApp.ts
+++ b/apps/api/tests/integration/helpers/testApp.ts
@@ -1,0 +1,18 @@
+import { errorHandler } from '../../../src/errors.js';
+import type { AuthContext } from '../../../src/middleware/auth.js';
+import { createOpenApiApp } from '../../../src/openapi.js';
+
+export function createIntegrationTestApp() {
+  const app = createOpenApiApp();
+
+  app.use('/api/*', async (c, next) => {
+    const rawAuth = c.req.header('x-test-auth');
+    const auth = rawAuth ? (JSON.parse(rawAuth) as AuthContext) : {};
+    c.set('auth', auth);
+    await next();
+  });
+
+  app.onError(errorHandler);
+
+  return app;
+}

--- a/apps/api/tests/integration/helpers/testDb.ts
+++ b/apps/api/tests/integration/helpers/testDb.ts
@@ -1,0 +1,39 @@
+import { PGlite } from '@electric-sql/pglite';
+import { pushSchema } from 'drizzle-kit/api';
+import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import * as schema from '../../../src/db/schema/index.js';
+
+function createDrizzleDb(client: PGlite) {
+  return drizzle(client, { schema });
+}
+
+export type TestDatabase = {
+  client: PGlite;
+  db: ReturnType<typeof createDrizzleDb>;
+  reset: () => Promise<void>;
+  close: () => Promise<void>;
+};
+
+export async function createTestDatabase(): Promise<TestDatabase> {
+  const client = new PGlite();
+  const db = createDrizzleDb(client);
+  const pgDb = db as unknown as PgDatabase<PgQueryResultHKT>;
+
+  const push = await pushSchema(schema, pgDb);
+  await push.apply();
+
+  return {
+    client,
+    db,
+    reset: async () => {
+      await client.exec('DROP SCHEMA IF EXISTS public CASCADE;');
+      await client.exec('CREATE SCHEMA public;');
+      const resetPush = await pushSchema(schema, pgDb);
+      await resetPush.apply();
+    },
+    close: async () => {
+      await client.close();
+    },
+  };
+}

--- a/apps/api/tests/integration/routes/teams.test.ts
+++ b/apps/api/tests/integration/routes/teams.test.ts
@@ -1,0 +1,313 @@
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { teams, tournaments } from '../../../src/db/schema/index.js';
+import { createIntegrationTestApp } from '../helpers/testApp.js';
+import { createTestDatabase, type TestDatabase } from '../helpers/testDb.js';
+
+process.env.DATABASE_URL ??= 'postgres://postgres:postgres@localhost:5432/wifiman_test';
+process.env.BETTER_AUTH_SECRET ??= 'test-secret-key-minimum-length';
+process.env.BETTER_AUTH_URL ??= 'http://localhost:3000';
+process.env.APP_ORIGIN ??= 'http://localhost:5173';
+
+type TestState = {
+  db: TestDatabase | null;
+};
+
+const state = vi.hoisted<TestState>(() => ({
+  db: null,
+}));
+
+vi.mock('../../../src/db/index.js', () => ({
+  get db() {
+    if (!state.db) {
+      throw new Error('Test DB is not initialized');
+    }
+    return state.db.db;
+  },
+}));
+
+describe('teams routes integration (pglite)', () => {
+  let teamRoutes: Awaited<typeof import('../../../src/routes/teams.js')>['default'];
+
+  beforeAll(async () => {
+    state.db = await createTestDatabase();
+    ({ default: teamRoutes } = await import('../../../src/routes/teams.js'));
+  });
+
+  afterAll(async () => {
+    await state.db?.close();
+  });
+
+  beforeEach(async () => {
+    await state.db?.reset();
+  });
+
+  it('GET /api/tournaments/:id/teams: 正常系', async () => {
+    if (!state.db) throw new Error('db is not initialized');
+
+    const tournamentId = '00000000-0000-4000-8000-000000000001';
+    await state.db.db.insert(tournaments).values({
+      id: tournamentId,
+      name: 'Tournament One',
+      venueName: 'Venue A',
+      startDate: '2026-04-01',
+      endDate: '2026-04-02',
+      description: null,
+    });
+
+    await state.db.db.insert(teams).values([
+      {
+        id: '00000000-0000-4000-8000-000000000011',
+        tournamentId,
+        name: 'Team A',
+        contactEmail: 'team-a@example.com',
+        displayContactName: 'Team A Contact',
+      },
+      {
+        id: '00000000-0000-4000-8000-000000000012',
+        tournamentId,
+        name: 'Team B',
+        contactEmail: 'team-b@example.com',
+        displayContactName: 'Team B Contact',
+      },
+    ]);
+
+    const app = createIntegrationTestApp();
+    app.route('/api', teamRoutes);
+
+    const res = await app.request(`/api/tournaments/${tournamentId}/teams`, {
+      method: 'GET',
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<Record<string, unknown>>;
+    expect(body).toHaveLength(2);
+    const teamA = body.find((row) => row.id === '00000000-0000-4000-8000-000000000011');
+    expect(teamA?.name).toBe('Team A');
+    expect(teamA).not.toHaveProperty('contactEmail');
+    expect(teamA).not.toHaveProperty('displayContactName');
+  });
+
+  it('POST /api/tournaments/:id/teams: operator は作成成功', async () => {
+    if (!state.db) throw new Error('db is not initialized');
+
+    const tournamentId = '00000000-0000-4000-8000-000000000002';
+    await state.db.db.insert(tournaments).values({
+      id: tournamentId,
+      name: 'Tournament Two',
+      venueName: 'Venue B',
+      startDate: '2026-05-01',
+      endDate: '2026-05-02',
+      description: null,
+    });
+
+    const app = createIntegrationTestApp();
+    app.route('/api', teamRoutes);
+
+    const res = await app.request(`/api/tournaments/${tournamentId}/teams`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': JSON.stringify({
+          userId: 'user-operator',
+          userRole: 'operator',
+        }),
+      },
+      body: JSON.stringify({
+        name: 'Team New',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      id: string;
+      name: string;
+      tournamentId: string;
+    };
+    expect(body.name).toBe('Team New');
+    expect(body.tournamentId).toBe(tournamentId);
+
+    const inserted = await state.db.db.query.teams.findFirst({
+      where: eq(teams.id, body.id),
+    });
+    expect(inserted?.name).toBe('Team New');
+    expect(inserted?.tournamentId).toBe(tournamentId);
+  });
+
+  it('POST /api/tournaments/:id/teams: 未認証は 401', async () => {
+    if (!state.db) throw new Error('db is not initialized');
+
+    const tournamentId = '00000000-0000-4000-8000-000000000004';
+    await state.db.db.insert(tournaments).values({
+      id: tournamentId,
+      name: 'Tournament Four',
+      venueName: 'Venue D',
+      startDate: '2026-07-01',
+      endDate: '2026-07-02',
+      description: null,
+    });
+
+    const app = createIntegrationTestApp();
+    app.route('/api', teamRoutes);
+
+    const res = await app.request(`/api/tournaments/${tournamentId}/teams`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Team Unauthorized',
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('UNAUTHORIZED');
+  });
+
+  it('POST /api/tournaments/:id/teams: non-operator は 403', async () => {
+    if (!state.db) throw new Error('db is not initialized');
+
+    const tournamentId = '00000000-0000-4000-8000-000000000003';
+    await state.db.db.insert(tournaments).values({
+      id: tournamentId,
+      name: 'Tournament Three',
+      venueName: 'Venue C',
+      startDate: '2026-06-01',
+      endDate: '2026-06-02',
+      description: null,
+    });
+
+    const app = createIntegrationTestApp();
+    app.route('/api', teamRoutes);
+
+    const res = await app.request(`/api/tournaments/${tournamentId}/teams`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': JSON.stringify({
+          userId: 'user-normal',
+          userRole: 'user',
+        }),
+      },
+      body: JSON.stringify({
+        name: 'Team Forbidden',
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('FORBIDDEN');
+
+    const createdTeams = await state.db.db
+      .select()
+      .from(teams)
+      .where(eq(teams.tournamentId, tournamentId));
+    expect(createdTeams).toHaveLength(0);
+  });
+
+  it('POST /api/tournaments/:id/teams: 大会なしは 404', async () => {
+    if (!state.db) throw new Error('db is not initialized');
+
+    const app = createIntegrationTestApp();
+    app.route('/api', teamRoutes);
+
+    const res = await app.request('/api/tournaments/00000000-0000-4000-8000-000000000099/teams', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': JSON.stringify({
+          userId: 'user-operator',
+          userRole: 'operator',
+        }),
+      },
+      body: JSON.stringify({
+        name: 'Team Missing Tournament',
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('NOT_FOUND');
+  });
+
+  it('POST /api/tournaments/:id/teams: 同名競合は 409', async () => {
+    if (!state.db) throw new Error('db is not initialized');
+
+    const tournamentId = '00000000-0000-4000-8000-000000000005';
+    await state.db.db.insert(tournaments).values({
+      id: tournamentId,
+      name: 'Tournament Five',
+      venueName: 'Venue E',
+      startDate: '2026-08-01',
+      endDate: '2026-08-02',
+      description: null,
+    });
+    await state.db.db.insert(teams).values({
+      id: '00000000-0000-4000-8000-000000000051',
+      tournamentId,
+      name: 'Team Duplicate',
+      organization: null,
+      pitId: null,
+      contactEmail: null,
+      displayContactName: null,
+      notes: null,
+    });
+
+    const app = createIntegrationTestApp();
+    app.route('/api', teamRoutes);
+
+    const res = await app.request(`/api/tournaments/${tournamentId}/teams`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': JSON.stringify({
+          userId: 'user-operator',
+          userRole: 'operator',
+        }),
+      },
+      body: JSON.stringify({
+        name: 'Team Duplicate',
+      }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('CONFLICT');
+  });
+
+  it('POST /api/tournaments/:id/teams: バリデーション不正は 400', async () => {
+    if (!state.db) throw new Error('db is not initialized');
+
+    const tournamentId = '00000000-0000-4000-8000-000000000006';
+    await state.db.db.insert(tournaments).values({
+      id: tournamentId,
+      name: 'Tournament Six',
+      venueName: 'Venue F',
+      startDate: '2026-09-01',
+      endDate: '2026-09-02',
+      description: null,
+    });
+
+    const app = createIntegrationTestApp();
+    app.route('/api', teamRoutes);
+
+    const res = await app.request(`/api/tournaments/${tournamentId}/teams`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': JSON.stringify({
+          userId: 'user-operator',
+          userRole: 'operator',
+        }),
+      },
+      body: JSON.stringify({
+        name: '',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,10 +35,10 @@ importers:
         version: link:../../packages/shared
       better-auth:
         specifier: ^1.6.5
-        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9)
       hono:
         specifier: ^4.7.10
         version: 4.12.14
@@ -52,6 +52,9 @@ importers:
         specifier: ^3.25.17
         version: 3.25.76
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.4.4
+        version: 0.4.4
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.17
@@ -241,6 +244,9 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@electric-sql/pglite@0.4.4':
+    resolution: {integrity: sha512-g/6CWAJ4XOkObWCWAQ2IReZD8VvsDy3poRHSKvpRR2F96F8WJ3HVbjpso3gN7l0q6QPPgvxSSpl/qo5k8a7mkQ==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -1450,12 +1456,12 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))':
+  '@better-auth/drizzle-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))':
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9)
 
   '@better-auth/kysely-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)':
     dependencies:
@@ -1527,6 +1533,8 @@ snapshots:
     optional: true
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@electric-sql/pglite@0.4.4': {}
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
@@ -1929,10 +1937,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)):
+  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))
+      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))
       '@better-auth/kysely-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
       '@better-auth/memory-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
@@ -1950,7 +1958,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9)
       vitest: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -2015,8 +2023,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9):
     optionalDependencies:
+      '@electric-sql/pglite': 0.4.4
       '@opentelemetry/api': 1.9.1
       kysely: 0.28.16
       postgres: 3.4.9


### PR DESCRIPTION
## 概要
Hono testing方式で API 統合テストを拡張し、teams ルートのDBモックを配列ベースから drizzle-test-suite (PGlite + Drizzle) に移行しました。あわせて、teamErrors の一意制約検知を cause 経由のエラーにも対応させ、回帰防止テストを追加しています。

Closes #10

## 変更点
- teams 統合テストを PGlite + Drizzle スキーマ適用で実行する test DB ヘルパーへ移行
- test app を createOpenApiApp ベースに変更し、本番 defaultHook と整合
- teams の POST に対して 401/404/409/400 の統合テストケースを追加
- teamErrors の一意制約判定を cause 内の Postgres エラーまで辿るよう補強
- teamErrors ユニットテストに cause ケースを追加
- テスト実行に必要な依存として @electric-sql/pglite を追加

## テスト結果
- pnpm lint: pass
- pnpm typecheck: pass
- pnpm --filter @wifiman/api test: pass (38 tests)
- teams integration: pass
- teamErrors unit: pass

## 注意点
- teams 統合テストは pglite 上で都度スキーマを再適用するため、従来の配列モックより実挙動に近い検証になります。