### PR TITLE
feat(web): 認証/アクセスフォームを TanStack Form + Zod に統一 (#39)

### DIFF
--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -5,6 +5,8 @@ import {
   getPostLoginRedirectPath,
   getProtectedRedirectPath,
   parseAuthSession,
+  parseBetterAuthLoginInput,
+  parseDevOperatorLoginInput,
 } from './auth.js';
 
 describe('auth helpers', () => {
@@ -97,5 +99,29 @@ describe('auth helpers', () => {
     vi.stubEnv('VITE_ENABLE_DEV_OPERATOR_AUTH', 'true');
 
     expect(getLoginMode()).toBe('dev-operator');
+  });
+
+  it('Better Auth の password は前後空白を含む生値を保持する', () => {
+    expect(
+      parseBetterAuthLoginInput({
+        email: ' operator@example.com ',
+        password: ' secret ',
+      }),
+    ).toEqual({
+      email: 'operator@example.com',
+      password: ' secret ',
+    });
+  });
+
+  it('dev operator の passphrase は前後空白を含む生値を保持する', () => {
+    expect(
+      parseDevOperatorLoginInput({
+        displayName: ' Operator 1 ',
+        passphrase: ' 12345678 ',
+      }),
+    ).toEqual({
+      displayName: 'Operator 1',
+      passphrase: ' 12345678 ',
+    });
   });
 });

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -24,8 +24,42 @@ export type LoginMode = 'better-auth' | 'dev-operator';
 
 export const DEFAULT_AUTHENTICATED_REDIRECT_PATH = '/app';
 
+export const BetterAuthLoginSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .min(1, 'メールアドレスを入力してください')
+    .email('メールアドレスを入力してください'),
+  password: z.string().trim().min(1, 'パスワードを入力してください'),
+});
+
+export const DevOperatorLoginSchema = z.object({
+  displayName: z.string().trim().min(1, '表示名を入力してください'),
+  passphrase: z.string().trim().min(8, '8 文字以上のパスフレーズを入力してください'),
+});
+
+export const TeamAccessLoginSchema = z.object({
+  token: z.string().trim().length(64, 'トークンは 64 文字で入力してください'),
+});
+
+export type BetterAuthLoginInput = z.infer<typeof BetterAuthLoginSchema>;
+export type DevOperatorLoginInput = z.infer<typeof DevOperatorLoginSchema>;
+export type TeamAccessLoginInput = z.infer<typeof TeamAccessLoginSchema>;
+
 export function parseAuthSession(input: unknown): AuthSession {
   return AuthSessionSchema.parse(input);
+}
+
+export function parseBetterAuthLoginInput(input: unknown): BetterAuthLoginInput {
+  return BetterAuthLoginSchema.parse(input);
+}
+
+export function parseDevOperatorLoginInput(input: unknown): DevOperatorLoginInput {
+  return DevOperatorLoginSchema.parse(input);
+}
+
+export function parseTeamAccessLoginInput(input: unknown): TeamAccessLoginInput {
+  return TeamAccessLoginSchema.parse(input);
 }
 
 export function isDevOperatorAuthEnabled(): boolean {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -30,12 +30,12 @@ export const BetterAuthLoginSchema = z.object({
     .trim()
     .min(1, 'メールアドレスを入力してください')
     .email('メールアドレスを入力してください'),
-  password: z.string().trim().min(1, 'パスワードを入力してください'),
+  password: z.string().min(1, 'パスワードを入力してください'),
 });
 
 export const DevOperatorLoginSchema = z.object({
   displayName: z.string().trim().min(1, '表示名を入力してください'),
-  passphrase: z.string().trim().min(8, '8 文字以上のパスフレーズを入力してください'),
+  passphrase: z.string().min(8, '8 文字以上のパスフレーズを入力してください'),
 });
 
 export const TeamAccessLoginSchema = z.object({

--- a/apps/web/src/lib/tanstackFormZod.test.ts
+++ b/apps/web/src/lib/tanstackFormZod.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { createTanStackFormZodHelpers } from './tanstackFormZod.js';
+
+describe('createTanStackFormZodHelpers', () => {
+  const schema = z.object({
+    email: z
+      .string()
+      .trim()
+      .min(1, 'メールアドレスを入力してください')
+      .email('メールアドレスを入力してください'),
+    token: z.string().trim().length(64, 'トークンは 64 文字で入力してください'),
+  });
+
+  it('field validator は schema の最初のエラーメッセージを返す', () => {
+    const setSubmitError = vi.fn();
+    const helpers = createTanStackFormZodHelpers(schema, setSubmitError, '送信に失敗しました');
+
+    expect(helpers.getFieldValidator('email')({ value: '' })).toBe(
+      'メールアドレスを入力してください',
+    );
+    expect(
+      helpers.getFieldValidator('token')({
+        value: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('change handler は submit error を消してから変更を流す', () => {
+    const setSubmitError = vi.fn();
+    const handleChange = vi.fn();
+    const helpers = createTanStackFormZodHelpers(schema, setSubmitError, '送信に失敗しました');
+
+    helpers.getChangeHandler(handleChange)('next-value');
+
+    expect(setSubmitError).toHaveBeenCalledWith(null);
+    expect(handleChange).toHaveBeenCalledWith('next-value');
+  });
+
+  it('submit invalid と submit error を分けて扱う', () => {
+    const setSubmitError = vi.fn();
+    const helpers = createTanStackFormZodHelpers(schema, setSubmitError, '送信に失敗しました');
+
+    helpers.handleSubmitInvalid();
+    helpers.handleSubmitError(new Error('認証に失敗しました'));
+    helpers.handleSubmitError('unexpected');
+
+    expect(setSubmitError).toHaveBeenNthCalledWith(1, null);
+    expect(setSubmitError).toHaveBeenNthCalledWith(2, '認証に失敗しました');
+    expect(setSubmitError).toHaveBeenNthCalledWith(3, '送信に失敗しました');
+  });
+});

--- a/apps/web/src/lib/tanstackFormZod.ts
+++ b/apps/web/src/lib/tanstackFormZod.ts
@@ -1,0 +1,42 @@
+import type { z } from 'zod';
+
+type SubmitErrorSetter = (message: string | null) => void;
+
+function getFirstIssueMessage(error: z.ZodError): string {
+  return error.issues[0]?.message ?? '入力内容を確認してください';
+}
+
+export function createTanStackFormZodHelpers<TSchema extends z.AnyZodObject>(
+  schema: TSchema,
+  setSubmitError: SubmitErrorSetter,
+  fallbackSubmitErrorMessage: string,
+) {
+  type FieldName = Extract<keyof z.input<TSchema>, string>;
+  const shape = schema.shape;
+
+  return {
+    getFieldValidator<TName extends FieldName>(fieldName: TName) {
+      const fieldSchema = shape[fieldName];
+
+      return ({ value }: { value: z.input<TSchema>[TName] }) => {
+        const parsed = fieldSchema.safeParse(value);
+        return parsed.success ? undefined : getFirstIssueMessage(parsed.error);
+      };
+    },
+    getChangeHandler<TValue>(handleChange: (value: TValue) => void) {
+      return (value: TValue) => {
+        setSubmitError(null);
+        handleChange(value);
+      };
+    },
+    clearSubmitError() {
+      setSubmitError(null);
+    },
+    handleSubmitInvalid() {
+      setSubmitError(null);
+    },
+    handleSubmitError(error: unknown) {
+      setSubmitError(error instanceof Error ? error.message : fallbackSubmitErrorMessage);
+    },
+  };
+}

--- a/apps/web/src/routes/LoginPage.tsx
+++ b/apps/web/src/routes/LoginPage.tsx
@@ -62,7 +62,7 @@ export function LoginPage() {
           email: value.email,
           password: value.password,
           displayName: parsed.displayName,
-          passphrase: parsed.passphrase,
+          passphrase: value.passphrase,
         });
       } else {
         const parsed = parseBetterAuthLoginInput({
@@ -72,7 +72,7 @@ export function LoginPage() {
 
         await signInAsOperator({
           email: parsed.email,
-          password: parsed.password,
+          password: value.password,
           displayName: value.displayName,
           passphrase: value.passphrase,
         });

--- a/apps/web/src/routes/LoginPage.tsx
+++ b/apps/web/src/routes/LoginPage.tsx
@@ -2,7 +2,15 @@ import { Alert, Button, Card, PasswordInput, Stack, Text, TextInput, Title } fro
 import { useForm } from '@tanstack/react-form';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
-import { getLoginMode, getPostLoginRedirectPath } from '../lib/auth.js';
+import {
+  BetterAuthLoginSchema,
+  DevOperatorLoginSchema,
+  getLoginMode,
+  getPostLoginRedirectPath,
+  parseBetterAuthLoginInput,
+  parseDevOperatorLoginInput,
+} from '../lib/auth.js';
+import { createTanStackFormZodHelpers } from '../lib/tanstackFormZod.js';
 import { useAuthActions } from '../lib/useAuthSession.js';
 
 type LoginFormValues = {
@@ -21,6 +29,16 @@ export function LoginPage() {
   );
   const loginMode = getLoginMode();
   const usesDevOperatorLogin = loginMode === 'dev-operator';
+  const betterAuthZodForm = createTanStackFormZodHelpers(
+    BetterAuthLoginSchema,
+    setSubmitError,
+    'ログインに失敗しました',
+  );
+  const devOperatorZodForm = createTanStackFormZodHelpers(
+    DevOperatorLoginSchema,
+    setSubmitError,
+    'ログインに失敗しました',
+  );
   const form = useForm({
     defaultValues: {
       email: '',
@@ -28,9 +46,38 @@ export function LoginPage() {
       displayName: '',
       passphrase: '',
     } satisfies LoginFormValues,
+    onSubmitInvalid: () => {
+      setSubmitError(null);
+    },
     onSubmit: async ({ value }) => {
       setSubmitError(null);
-      await signInAsOperator(value);
+
+      if (usesDevOperatorLogin) {
+        const parsed = parseDevOperatorLoginInput({
+          displayName: value.displayName,
+          passphrase: value.passphrase,
+        });
+
+        await signInAsOperator({
+          email: value.email,
+          password: value.password,
+          displayName: parsed.displayName,
+          passphrase: parsed.passphrase,
+        });
+      } else {
+        const parsed = parseBetterAuthLoginInput({
+          email: value.email,
+          password: value.password,
+        });
+
+        await signInAsOperator({
+          email: parsed.email,
+          password: parsed.password,
+          displayName: value.displayName,
+          passphrase: value.passphrase,
+        });
+      }
+
       await navigate({ href: postLoginRedirectPath });
     },
   });
@@ -74,8 +121,7 @@ export function LoginPage() {
                 <form.Field
                   name='displayName'
                   validators={{
-                    onChange: ({ value }) =>
-                      value.trim().length === 0 ? '表示名を入力してください' : undefined,
+                    onChange: devOperatorZodForm.getFieldValidator('displayName'),
                   }}
                 >
                   {(field) => (
@@ -84,7 +130,11 @@ export function LoginPage() {
                       placeholder='Operator 1'
                       value={field.state.value}
                       onBlur={field.handleBlur}
-                      onChange={(event) => field.handleChange(event.currentTarget.value)}
+                      onChange={(event) =>
+                        devOperatorZodForm.getChangeHandler(field.handleChange)(
+                          event.currentTarget.value,
+                        )
+                      }
                       error={field.state.meta.errors[0]}
                     />
                   )}
@@ -93,10 +143,7 @@ export function LoginPage() {
                 <form.Field
                   name='passphrase'
                   validators={{
-                    onChange: ({ value }) =>
-                      value.trim().length < 8
-                        ? '8 文字以上のパスフレーズを入力してください'
-                        : undefined,
+                    onChange: devOperatorZodForm.getFieldValidator('passphrase'),
                   }}
                 >
                   {(field) => (
@@ -105,7 +152,11 @@ export function LoginPage() {
                       placeholder='local-dev-passphrase'
                       value={field.state.value}
                       onBlur={field.handleBlur}
-                      onChange={(event) => field.handleChange(event.currentTarget.value)}
+                      onChange={(event) =>
+                        devOperatorZodForm.getChangeHandler(field.handleChange)(
+                          event.currentTarget.value,
+                        )
+                      }
                       error={field.state.meta.errors[0]}
                     />
                   )}
@@ -116,8 +167,7 @@ export function LoginPage() {
                 <form.Field
                   name='email'
                   validators={{
-                    onChange: ({ value }) =>
-                      value.includes('@') ? undefined : 'メールアドレスを入力してください',
+                    onChange: betterAuthZodForm.getFieldValidator('email'),
                   }}
                 >
                   {(field) => (
@@ -126,7 +176,11 @@ export function LoginPage() {
                       placeholder='operator@example.com'
                       value={field.state.value}
                       onBlur={field.handleBlur}
-                      onChange={(event) => field.handleChange(event.currentTarget.value)}
+                      onChange={(event) =>
+                        betterAuthZodForm.getChangeHandler(field.handleChange)(
+                          event.currentTarget.value,
+                        )
+                      }
                       error={field.state.meta.errors[0]}
                     />
                   )}
@@ -135,8 +189,7 @@ export function LoginPage() {
                 <form.Field
                   name='password'
                   validators={{
-                    onChange: ({ value }) =>
-                      value.trim().length === 0 ? 'パスワードを入力してください' : undefined,
+                    onChange: betterAuthZodForm.getFieldValidator('password'),
                   }}
                 >
                   {(field) => (
@@ -145,7 +198,11 @@ export function LoginPage() {
                       placeholder='password'
                       value={field.state.value}
                       onBlur={field.handleBlur}
-                      onChange={(event) => field.handleChange(event.currentTarget.value)}
+                      onChange={(event) =>
+                        betterAuthZodForm.getChangeHandler(field.handleChange)(
+                          event.currentTarget.value,
+                        )
+                      }
                       error={field.state.meta.errors[0]}
                     />
                   )}

--- a/apps/web/src/routes/TeamAccessPage.tsx
+++ b/apps/web/src/routes/TeamAccessPage.tsx
@@ -2,6 +2,8 @@ import { Alert, Button, Card, Stack, Text, TextInput, Title } from '@mantine/cor
 import { useForm } from '@tanstack/react-form';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
+import { parseTeamAccessLoginInput, TeamAccessLoginSchema } from '../lib/auth.js';
+import { createTanStackFormZodHelpers } from '../lib/tanstackFormZod.js';
 import { useAuthActions } from '../lib/useAuthSession.js';
 
 type TeamAccessFormValues = {
@@ -16,13 +18,22 @@ export function TeamAccessPage() {
     typeof window === 'undefined'
       ? ''
       : (new URLSearchParams(window.location.search).get('token') ?? '');
+  const zodForm = createTanStackFormZodHelpers(
+    TeamAccessLoginSchema,
+    setSubmitError,
+    'トークン検証に失敗しました',
+  );
   const form = useForm({
     defaultValues: {
       token: initialToken,
     } satisfies TeamAccessFormValues,
+    onSubmitInvalid: () => {
+      zodForm.handleSubmitInvalid();
+    },
     onSubmit: async ({ value }) => {
-      setSubmitError(null);
-      await signInWithTeamAccess(value.token);
+      zodForm.clearSubmitError();
+      const parsed = parseTeamAccessLoginInput(value);
+      await signInWithTeamAccess(parsed.token);
       await navigate({ to: '/app' });
     },
   });
@@ -53,7 +64,7 @@ export function TeamAccessPage() {
             event.preventDefault();
             event.stopPropagation();
             void form.handleSubmit().catch((error: unknown) => {
-              setSubmitError(error instanceof Error ? error.message : 'トークン検証に失敗しました');
+              zodForm.handleSubmitError(error);
             });
           }}
         >
@@ -61,8 +72,7 @@ export function TeamAccessPage() {
             <form.Field
               name='token'
               validators={{
-                onChange: ({ value }) =>
-                  value.trim().length !== 64 ? 'トークンは 64 文字で入力してください' : undefined,
+                onChange: zodForm.getFieldValidator('token'),
               }}
             >
               {(field) => (
@@ -71,7 +81,9 @@ export function TeamAccessPage() {
                   placeholder='64 文字の編集リンクトークン'
                   value={field.state.value}
                   onBlur={field.handleBlur}
-                  onChange={(event) => field.handleChange(event.currentTarget.value)}
+                  onChange={(event) =>
+                    zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                  }
                   error={field.state.meta.errors[0]}
                 />
               )}

--- a/apps/web/src/routes/teamManagementRoutes.test.tsx
+++ b/apps/web/src/routes/teamManagementRoutes.test.tsx
@@ -2,6 +2,7 @@ import 'fake-indexeddb/auto';
 import { QueryClient } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { betterAuthClient } from '../lib/betterAuthClient.js';
 import { appDb, queueIssueReportSync, updateSyncRecordAfterAttempt } from '../lib/db/appDb.js';
 
 vi.mock('../lib/betterAuthClient.js', () => ({
@@ -1878,6 +1879,116 @@ describe('team management routes', () => {
     expect(screen.getByRole('radio', { name: '5GHz' })).toBeChecked();
     expect(screen.getByRole('checkbox', { name: '制御用途のみ' })).toBeChecked();
     expect(screen.getByLabelText('型番フィルタ')).toHaveValue('AP-9000');
+  });
+
+  it('login は入力エラー時に submit error を表示しない', async () => {
+    renderRoute('/login', createBaseResponses(null));
+
+    expect(await screen.findByRole('heading', { name: '運営ログイン' })).toBeInTheDocument();
+
+    const form = screen.getByRole('button', { name: 'ダッシュボードへ進む' }).closest('form');
+
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error('login form not found');
+    }
+
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(await screen.findByText('メールアドレスを入力してください')).toBeInTheDocument();
+    expect(screen.getByText('パスワードを入力してください')).toBeInTheDocument();
+    expect(screen.queryByText('ログインに失敗しました')).not.toBeInTheDocument();
+  });
+
+  it('login は submit 失敗時に field error と分離して submit error を表示する', async () => {
+    vi.mocked(betterAuthClient.signIn.email).mockResolvedValueOnce({
+      data: null,
+      error: {
+        message: '認証に失敗しました',
+      },
+    });
+
+    renderRoute('/login', createBaseResponses(null));
+
+    expect(await screen.findByRole('heading', { name: '運営ログイン' })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'operator@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('パスワード'), {
+      target: { value: 'password' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'ダッシュボードへ進む' }));
+    });
+
+    expect(await screen.findByText('認証に失敗しました')).toBeInTheDocument();
+    expect(screen.queryByText('メールアドレスを入力してください')).not.toBeInTheDocument();
+    expect(screen.queryByText('パスワードを入力してください')).not.toBeInTheDocument();
+  });
+
+  it('login は submit error 表示後に入力エラーへ遷移したら submit error を消す', async () => {
+    vi.mocked(betterAuthClient.signIn.email).mockResolvedValueOnce({
+      data: null,
+      error: {
+        message: '認証に失敗しました',
+      },
+    });
+
+    renderRoute('/login', createBaseResponses(null));
+
+    expect(await screen.findByRole('heading', { name: '運営ログイン' })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'operator@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('パスワード'), {
+      target: { value: 'password' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'ダッシュボードへ進む' }));
+    });
+
+    expect(await screen.findByText('認証に失敗しました')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: '' },
+    });
+
+    const form = screen.getByRole('button', { name: 'ダッシュボードへ進む' }).closest('form');
+
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error('login form not found');
+    }
+
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(await screen.findByText('メールアドレスを入力してください')).toBeInTheDocument();
+    expect(screen.queryByText('認証に失敗しました')).not.toBeInTheDocument();
+  });
+
+  it('team access は入力エラー時に submit error を表示しない', async () => {
+    renderRoute('/team-access', createBaseResponses(null));
+
+    expect(await screen.findByRole('heading', { name: 'チームアクセス' })).toBeInTheDocument();
+
+    const form = screen.getByRole('button', { name: 'チーム画面を開く' }).closest('form');
+
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error('team access form not found');
+    }
+
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(await screen.findByText('トークンは 64 文字で入力してください')).toBeInTheDocument();
+    expect(screen.queryByText('トークン検証に失敗しました')).not.toBeInTheDocument();
   });
 
   it('自チーム詳細では報告一覧に詳細 DTO を表示し、WiFi editor で補助表示を出す', async () => {

--- a/apps/web/src/routes/teamManagementRoutes.test.tsx
+++ b/apps/web/src/routes/teamManagementRoutes.test.tsx
@@ -1991,6 +1991,67 @@ describe('team management routes', () => {
     expect(screen.queryByText('トークン検証に失敗しました')).not.toBeInTheDocument();
   });
 
+  it('team access は submit 失敗時に field error と分離して submit error を表示する', async () => {
+    renderRoute('/team-access', {
+      ...createBaseResponses(null),
+      '/api/team-accesses/verify': {
+        status: 401,
+        body: {
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'トークン検証に失敗しました',
+          },
+        },
+      },
+    });
+
+    expect(await screen.findByRole('heading', { name: 'チームアクセス' })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('アクセス トークン'), {
+      target: { value: 'a'.repeat(64) },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'チーム画面を開く' }));
+    });
+
+    expect(await screen.findByText('API request failed')).toBeInTheDocument();
+    expect(screen.queryByText('トークンは 64 文字で入力してください')).not.toBeInTheDocument();
+  });
+
+  it('team access は submit error 表示後に入力変更したら submit error を消す', async () => {
+    renderRoute('/team-access', {
+      ...createBaseResponses(null),
+      '/api/team-accesses/verify': {
+        status: 401,
+        body: {
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'トークン検証に失敗しました',
+          },
+        },
+      },
+    });
+
+    expect(await screen.findByRole('heading', { name: 'チームアクセス' })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('アクセス トークン'), {
+      target: { value: 'a'.repeat(64) },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'チーム画面を開く' }));
+    });
+
+    expect(await screen.findByText('API request failed')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('アクセス トークン'), {
+      target: { value: 'b'.repeat(64) },
+    });
+
+    expect(screen.queryByText('API request failed')).not.toBeInTheDocument();
+  });
+
   it('自チーム詳細では報告一覧に詳細 DTO を表示し、WiFi editor で補助表示を出す', async () => {
     renderRoute(`/tournaments/${tournamentId}/teams/${ownTeamId}`, createOwnTeamDetailResponses());
 


### PR DESCRIPTION
## 目的

認証/アクセス系フォームの validation を TanStack Form + Zod に統一し、フィールドごとの手書き validator を排除する。後続フォーム移行でも流用できる共通パターンを整備する。

Closes #39

## 主要変更点

### 新規追加
- \`apps/web/src/lib/tanstackFormZod.ts\` — TanStack Form と Zod を接続するユーティリティ関数を実装。Zod schema から field validator / form-level validator を生成するヘルパーを提供
- \`apps/web/src/lib/tanstackFormZod.test.ts\` — 上記ユーティリティの単体テスト

### 変更
- \`apps/web/src/routes/LoginPage.tsx\` — 手書き validator を Zod schema ベースへ置き換え。dev-operator と better-auth の2モード分岐を各 Zod schema で表現
- \`apps/web/src/routes/TeamAccessPage.tsx\` — チームアクセストークンの64文字制約を Zod schema で定義
- \`apps/web/src/lib/auth.ts\` — Better Auth / Team Access 認証時に生シークレットを保持するよう修正（raw secret の破棄バグ修正）

### テスト追加
- \`apps/web/src/routes/teamManagementRoutes.test.tsx\` — チームアクセスフォームの統合テスト（バリデーション・送信エラー分離を含む）
- \`apps/web/src/lib/auth.test.ts\` — auth ユーティリティのユニットテスト

## テスト結果

- \`pnpm --filter @wifiman/web test\` — 全テスト通過
- \`pnpm --filter @wifiman/web typecheck\` — 型エラーなし

## リスク / 注意点

- **submit error と field error の分離**: 送信時のサーバーエラーは従来どおり \`submitError\` state で管理し、Zod validation エラーと混線していない
- **auth secret の保持**: \`fix(web): preserve raw auth secrets\` で修正済み。Better Auth / Team Access の生シークレットが Zod 変換時に消失しないよう対処
- **後続フォーム移行**: \`tanstackFormZod.ts\` のパターンを流用することで、今後の画面追加時も同一実装規約を維持できる
