### PR TITLE
feat(web): チーム管理・運営フォームを TanStack Form + Zod に統一 (#40)

### DIFF
--- a/apps/web/src/lib/tanstackFormZod.ts
+++ b/apps/web/src/lib/tanstackFormZod.ts
@@ -1,0 +1,64 @@
+import type { z } from 'zod';
+
+type SubmitErrorSetter = (message: string | null) => void;
+type GlobalFormValidationError<TFormData extends Record<string, unknown>> = {
+  form?: string;
+  fields: Partial<Record<Extract<keyof TFormData, string>, string>>;
+};
+
+function getFirstIssueMessage(error: z.ZodError): string {
+  return error.issues[0]?.message ?? '入力内容を確認してください';
+}
+
+export function createTanStackFormZodHelpers<TSchema extends z.AnyZodObject>(
+  schema: TSchema,
+  setSubmitError: SubmitErrorSetter = () => undefined,
+  fallbackSubmitErrorMessage = '入力内容を確認してください',
+) {
+  type FieldName = Extract<keyof z.input<TSchema>, string>;
+  const shape = schema.shape;
+
+  return {
+    getFieldValidator<TName extends FieldName>(fieldName: TName) {
+      const fieldSchema = shape[fieldName];
+
+      return ({ value }: { value: z.input<TSchema>[TName] }) => {
+        const parsed = fieldSchema.safeParse(value);
+        return parsed.success ? undefined : getFirstIssueMessage(parsed.error);
+      };
+    },
+    getChangeHandler<TValue>(handleChange: (value: TValue) => void) {
+      return (value: TValue) => {
+        setSubmitError(null);
+        handleChange(value);
+      };
+    },
+    clearSubmitError() {
+      setSubmitError(null);
+    },
+    handleSubmitInvalid() {
+      setSubmitError(null);
+    },
+    handleSubmitError(error: unknown) {
+      setSubmitError(error instanceof Error ? error.message : fallbackSubmitErrorMessage);
+    },
+  };
+}
+
+export function toGlobalFormValidationError<TFormData extends Record<string, unknown>>(
+  fieldErrors: Partial<Record<Extract<keyof TFormData, string>, string>>,
+  formError?: string,
+): GlobalFormValidationError<TFormData> | undefined {
+  const fields = Object.fromEntries(
+    Object.entries(fieldErrors).filter(([, message]) => Boolean(message)),
+  ) as Partial<Record<Extract<keyof TFormData, string>, string>>;
+
+  if (!formError && Object.keys(fields).length === 0) {
+    return undefined;
+  }
+
+  return {
+    ...(formError ? { form: formError } : {}),
+    fields,
+  } satisfies GlobalFormValidationError<TFormData>;
+}

--- a/apps/web/src/lib/teamManagement.ts
+++ b/apps/web/src/lib/teamManagement.ts
@@ -19,9 +19,9 @@ import {
 } from '@wifiman/shared';
 import type { z } from 'zod';
 
-const TeamEditorSchema = CreateTeamSchema.omit({ tournamentId: true });
-const WifiConfigEditorSchema = CreateWifiConfigSchema.omit({ teamId: true });
-const DeviceSpecEditorSchema = CreateDeviceSpecSchema.omit({ teamId: true });
+export const TeamEditorSchema = CreateTeamSchema.omit({ tournamentId: true });
+export const WifiConfigEditorSchema = CreateWifiConfigSchema.omit({ teamId: true });
+export const DeviceSpecEditorSchema = CreateDeviceSpecSchema.omit({ teamId: true });
 
 export type TeamFormValues = {
   name: string;

--- a/apps/web/src/routes/AppDashboardPage.tsx
+++ b/apps/web/src/routes/AppDashboardPage.tsx
@@ -16,6 +16,7 @@ import {
   Title,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
+import { useForm } from '@tanstack/react-form';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { CreateNoticeSchema, CreateObservedWifiSchema } from '@wifiman/shared';
@@ -29,6 +30,7 @@ import {
   type ObservedWifiCreateInput,
 } from '../lib/api/client.js';
 import { getSyncOverview } from '../lib/db/appDb.js';
+import { createTanStackFormZodHelpers } from '../lib/tanstackFormZod.js';
 import { parseObservedWifiCsv } from '../lib/teamManagement.js';
 import {
   useBulkCreateObservedWifiMutation,
@@ -151,22 +153,92 @@ function toNoticeUpdateInput(values: NoticeFormValues): NoticeUpdateInput {
   };
 }
 
+function parseObservedWifiFormValues(values: ObservedWifiFormValues): {
+  data?: ObservedWifiDraft;
+  errors: Partial<Record<keyof ObservedWifiFormValues, string>>;
+} {
+  const parsed = CreateObservedWifiSchema.omit({ tournamentId: true }).safeParse({
+    source: values.source,
+    ssid: values.ssid.trim() || null,
+    bssid: values.bssid.trim() || null,
+    band: values.band,
+    channel: Number(values.channel),
+    channelWidthMHz: values.channelWidthMHz.trim() ? Number(values.channelWidthMHz) : null,
+    rssi: values.rssi.trim() ? Number(values.rssi) : null,
+    locationLabel: values.locationLabel.trim() || null,
+    observedAt: new Date(values.observedAt).toISOString(),
+    notes: values.notes.trim() || null,
+  });
+
+  if (parsed.success) {
+    return { data: parsed.data, errors: {} };
+  }
+
+  const errors: Partial<Record<keyof ObservedWifiFormValues, string>> = {};
+  for (const issue of parsed.error.issues) {
+    const field = issue.path[0];
+    if (typeof field === 'string' && !(field in errors)) {
+      errors[field as keyof ObservedWifiFormValues] = issue.message;
+    }
+  }
+
+  return { errors };
+}
+
+function parseNoticeFormValues(values: NoticeFormValues): {
+  createInput?: NoticeCreateInput;
+  updateInput?: NoticeUpdateInput;
+  errors: Partial<Record<keyof NoticeFormValues, string>>;
+} {
+  const createInput = toNoticeCreateInput(values);
+  const updateInput = toNoticeUpdateInput(values);
+  const parsed = CreateNoticeSchema.omit({ tournamentId: true }).safeParse(createInput);
+
+  if (parsed.success) {
+    return { createInput, updateInput, errors: {} };
+  }
+
+  const errors: Partial<Record<keyof NoticeFormValues, string>> = {};
+  for (const issue of parsed.error.issues) {
+    const field = issue.path[0];
+    if (typeof field === 'string' && !(field in errors)) {
+      errors[field as keyof NoticeFormValues] = issue.message;
+    }
+  }
+
+  return { errors };
+}
+
 export function AppDashboardPage() {
   const tournamentsQuery = useTournaments();
   const syncOverview = useQuery({
     queryKey: apiQueryKeys.syncOverview,
     queryFn: getSyncOverview,
   });
+  const observedWifiZodForm = createTanStackFormZodHelpers(CreateObservedWifiSchema);
+  const noticeZodForm = createTanStackFormZodHelpers(CreateNoticeSchema);
   const [selectedTournamentId, setSelectedTournamentId] = useState('');
   const [selectedTeamId, setSelectedTeamId] = useState('');
-  const [observedWifiValues, setObservedWifiValues] = useState<ObservedWifiFormValues>(
-    buildObservedWifiInitialValues,
-  );
-  const [csvInput, setCsvInput] = useState('');
+  const observedWifiForm = useForm({
+    defaultValues: buildObservedWifiInitialValues(),
+  });
+  const csvForm = useForm({
+    defaultValues: {
+      csvInput: '',
+    },
+  });
+  const noticeForm = useForm({
+    defaultValues: buildNoticeInitialValues(),
+  });
+  const [observedWifiFieldErrors, setObservedWifiFieldErrors] = useState<
+    Partial<Record<keyof ObservedWifiFormValues, string>>
+  >({});
   const [csvErrors, setCsvErrors] = useState<Array<{ row: number; message: string }>>([]);
   const [observedWifiError, setObservedWifiError] = useState<string | null>(null);
   const [editingNoticeId, setEditingNoticeId] = useState<string | null>(null);
-  const [noticeValues, setNoticeValues] = useState<NoticeFormValues>(buildNoticeInitialValues);
+  const [noticeFieldErrors, setNoticeFieldErrors] = useState<
+    Partial<Record<keyof NoticeFormValues, string>>
+  >({});
   const [noticeError, setNoticeError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -234,36 +306,24 @@ export function AppDashboardPage() {
   const issueReportCount = issueReportsQuery.data?.length ?? 0;
 
   const handleObservedWifiSubmit = async () => {
+    const values = observedWifiForm.state.values;
     setObservedWifiError(null);
+    setObservedWifiFieldErrors({});
 
     if (!selectedTournamentId) {
       setObservedWifiError('大会を選択してください');
       return;
     }
 
-    const parsed = CreateObservedWifiSchema.omit({ tournamentId: true }).safeParse({
-      source: observedWifiValues.source,
-      ssid: observedWifiValues.ssid.trim() || null,
-      bssid: observedWifiValues.bssid.trim() || null,
-      band: observedWifiValues.band,
-      channel: Number(observedWifiValues.channel),
-      channelWidthMHz: observedWifiValues.channelWidthMHz.trim()
-        ? Number(observedWifiValues.channelWidthMHz)
-        : null,
-      rssi: observedWifiValues.rssi.trim() ? Number(observedWifiValues.rssi) : null,
-      locationLabel: observedWifiValues.locationLabel.trim() || null,
-      observedAt: new Date(observedWifiValues.observedAt).toISOString(),
-      notes: observedWifiValues.notes.trim() || null,
-    });
-
-    if (!parsed.success) {
-      setObservedWifiError(parsed.error.issues[0]?.message ?? '入力内容を確認してください');
+    const parsed = parseObservedWifiFormValues(values);
+    if (!parsed.data) {
+      setObservedWifiFieldErrors(parsed.errors);
       return;
     }
 
     try {
       await createObservedWifiMutation.mutateAsync(toObservedWifiInput(parsed.data));
-      setObservedWifiValues(buildObservedWifiInitialValues());
+      observedWifiForm.reset(buildObservedWifiInitialValues());
       notifications.show({
         color: 'teal',
         title: '野良 WiFi を登録しました',
@@ -275,6 +335,7 @@ export function AppDashboardPage() {
   };
 
   const handleCsvImport = async () => {
+    const csvInput = csvForm.state.values.csvInput;
     setObservedWifiError(null);
 
     if (!selectedTournamentId) {
@@ -303,7 +364,7 @@ export function AppDashboardPage() {
         title: 'CSV を一括登録しました',
         message: `${result.count} 件を all-or-nothing で登録しました。`,
       });
-      setCsvInput('');
+      csvForm.reset({ csvInput: '' });
     } catch (error) {
       if (error instanceof ApiClientError) {
         const details = (
@@ -323,30 +384,26 @@ export function AppDashboardPage() {
   };
 
   const handleNoticeSubmit = async () => {
+    const values = noticeForm.state.values;
     setNoticeError(null);
+    setNoticeFieldErrors({});
 
     if (!selectedTournamentId) {
       setNoticeError('大会を選択してください');
       return;
     }
 
-    const createPayload = toNoticeCreateInput(noticeValues);
-    const updatePayload = toNoticeUpdateInput(noticeValues);
-
-    const parsed = editingNoticeId
-      ? CreateNoticeSchema.omit({ tournamentId: true }).safeParse(updatePayload)
-      : CreateNoticeSchema.omit({ tournamentId: true }).safeParse(createPayload);
-
-    if (!parsed.success) {
-      setNoticeError(parsed.error.issues[0]?.message ?? 'お知らせ入力を確認してください');
+    const parsed = parseNoticeFormValues(values);
+    if (!parsed.createInput || !parsed.updateInput) {
+      setNoticeFieldErrors(parsed.errors);
       return;
     }
 
     try {
       if (editingNoticeId) {
-        await updateNoticeMutation.mutateAsync({ id: editingNoticeId, input: updatePayload });
+        await updateNoticeMutation.mutateAsync({ id: editingNoticeId, input: parsed.updateInput });
       } else {
-        await createNoticeMutation.mutateAsync(createPayload);
+        await createNoticeMutation.mutateAsync(parsed.createInput);
       }
 
       notifications.show({
@@ -355,7 +412,7 @@ export function AppDashboardPage() {
         message: '大会トップの notices を更新しました。',
       });
       setEditingNoticeId(null);
-      setNoticeValues(buildNoticeInitialValues());
+      noticeForm.reset(buildNoticeInitialValues());
     } catch (error) {
       setNoticeError(error instanceof Error ? error.message : 'お知らせ保存に失敗しました');
     }
@@ -363,7 +420,9 @@ export function AppDashboardPage() {
 
   const handleStartNoticeEdit = (notice: NonNullable<typeof noticesQuery.data>[number]) => {
     setEditingNoticeId(notice.id);
-    setNoticeValues({
+    setNoticeFieldErrors({});
+    setNoticeError(null);
+    noticeForm.reset({
       title: notice.title,
       body: notice.body,
       severity: notice.severity,
@@ -512,147 +571,207 @@ export function AppDashboardPage() {
               </Alert>
 
               {observedWifiError ? <Alert color='red'>{observedWifiError}</Alert> : null}
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void handleObservedWifiSubmit();
+                }}
+              >
+                <observedWifiForm.Subscribe selector={(state) => state.values}>
+                  {(_values) => (
+                    <Stack gap='md'>
+                      <Grid>
+                        <Grid.Col span={{ base: 12, md: 6 }}>
+                          <observedWifiForm.Field name='source'>
+                            {(field) => (
+                              <NativeSelect
+                                label='source'
+                                data={[
+                                  { value: 'manual', label: 'manual' },
+                                  { value: 'wild', label: 'wild' },
+                                  { value: 'analyzer_import', label: 'analyzer_import' },
+                                ]}
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                    event.currentTarget.value as ObservedWifiFormValues['source'],
+                                  );
+                                }}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                        <Grid.Col span={{ base: 12, md: 6 }}>
+                          <observedWifiForm.Field name='ssid'>
+                            {(field) => (
+                              <TextInput
+                                label='SSID'
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                    event.currentTarget.value,
+                                  );
+                                }}
+                                error={observedWifiFieldErrors.ssid}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                        <Grid.Col span={{ base: 12, md: 6 }}>
+                          <observedWifiForm.Field name='bssid'>
+                            {(field) => (
+                              <TextInput
+                                label='BSSID'
+                                placeholder='00:11:22:33:44:55'
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                    event.currentTarget.value,
+                                  );
+                                }}
+                                error={observedWifiFieldErrors.bssid}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                        <Grid.Col span={{ base: 12, md: 3 }}>
+                          <observedWifiForm.Field name='band'>
+                            {(field) => (
+                              <NativeSelect
+                                label='帯域'
+                                data={['2.4GHz', '5GHz', '6GHz']}
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                    event.currentTarget.value as ObservedWifiFormValues['band'],
+                                  );
+                                }}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                        <Grid.Col span={{ base: 12, md: 3 }}>
+                          <observedWifiForm.Field name='channel'>
+                            {(field) => (
+                              <TextInput
+                                label='channel'
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  field.handleChange(event.currentTarget.value);
+                                }}
+                                error={observedWifiFieldErrors.channel}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                        <Grid.Col span={{ base: 12, md: 3 }}>
+                          <observedWifiForm.Field name='channelWidthMHz'>
+                            {(field) => (
+                              <TextInput
+                                label='channel width MHz'
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  field.handleChange(event.currentTarget.value);
+                                }}
+                                error={observedWifiFieldErrors.channelWidthMHz}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                        <Grid.Col span={{ base: 12, md: 3 }}>
+                          <observedWifiForm.Field name='rssi'>
+                            {(field) => (
+                              <TextInput
+                                label='RSSI'
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  field.handleChange(event.currentTarget.value);
+                                }}
+                                error={observedWifiFieldErrors.rssi}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                        <Grid.Col span={{ base: 12, md: 6 }}>
+                          <observedWifiForm.Field name='locationLabel'>
+                            {(field) => (
+                              <TextInput
+                                label='location'
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                    event.currentTarget.value,
+                                  );
+                                }}
+                                error={observedWifiFieldErrors.locationLabel}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                        <Grid.Col span={{ base: 12, md: 6 }}>
+                          <observedWifiForm.Field name='observedAt'>
+                            {(field) => (
+                              <TextInput
+                                label='observed at'
+                                type='datetime-local'
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  field.handleChange(event.currentTarget.value);
+                                }}
+                                error={observedWifiFieldErrors.observedAt}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                        <Grid.Col span={12}>
+                          <observedWifiForm.Field name='notes'>
+                            {(field) => (
+                              <Textarea
+                                label='notes'
+                                minRows={3}
+                                value={field.state.value}
+                                onChange={(event) => {
+                                  setObservedWifiError(null);
+                                  setObservedWifiFieldErrors({});
+                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                    event.currentTarget.value,
+                                  );
+                                }}
+                                error={observedWifiFieldErrors.notes}
+                              />
+                            )}
+                          </observedWifiForm.Field>
+                        </Grid.Col>
+                      </Grid>
 
-              <Grid>
-                <Grid.Col span={{ base: 12, md: 6 }}>
-                  <NativeSelect
-                    label='source'
-                    data={[
-                      { value: 'manual', label: 'manual' },
-                      { value: 'wild', label: 'wild' },
-                      { value: 'analyzer_import', label: 'analyzer_import' },
-                    ]}
-                    value={observedWifiValues.source}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        source: event.currentTarget.value as ObservedWifiFormValues['source'],
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 6 }}>
-                  <TextInput
-                    label='SSID'
-                    value={observedWifiValues.ssid}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        ssid: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 6 }}>
-                  <TextInput
-                    label='BSSID'
-                    placeholder='00:11:22:33:44:55'
-                    value={observedWifiValues.bssid}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        bssid: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 3 }}>
-                  <NativeSelect
-                    label='帯域'
-                    data={['2.4GHz', '5GHz', '6GHz']}
-                    value={observedWifiValues.band}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        band: event.currentTarget.value as ObservedWifiFormValues['band'],
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 3 }}>
-                  <TextInput
-                    label='channel'
-                    value={observedWifiValues.channel}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        channel: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 3 }}>
-                  <TextInput
-                    label='channel width MHz'
-                    value={observedWifiValues.channelWidthMHz}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        channelWidthMHz: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 3 }}>
-                  <TextInput
-                    label='RSSI'
-                    value={observedWifiValues.rssi}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        rssi: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 6 }}>
-                  <TextInput
-                    label='location'
-                    value={observedWifiValues.locationLabel}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        locationLabel: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 6 }}>
-                  <TextInput
-                    label='observed at'
-                    type='datetime-local'
-                    value={observedWifiValues.observedAt}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        observedAt: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={12}>
-                  <Textarea
-                    label='notes'
-                    minRows={3}
-                    value={observedWifiValues.notes}
-                    onChange={(event) =>
-                      setObservedWifiValues((current) => ({
-                        ...current,
-                        notes: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-              </Grid>
-
-              <Group justify='flex-end'>
-                <Button
-                  loading={createObservedWifiMutation.isPending}
-                  onClick={() => void handleObservedWifiSubmit()}
-                >
-                  野良 WiFi を登録
-                </Button>
-              </Group>
+                      <Group justify='flex-end'>
+                        <Button type='submit' loading={createObservedWifiMutation.isPending}>
+                          野良 WiFi を登録
+                        </Button>
+                      </Group>
+                    </Stack>
+                  )}
+                </observedWifiForm.Subscribe>
+              </form>
             </Stack>
           </Card>
         </Grid.Col>
@@ -668,34 +787,49 @@ export function AppDashboardPage() {
                 </Text>
               </div>
 
-              <Textarea
-                label='CSV'
-                minRows={10}
-                placeholder='source,ssid,bssid,band,channel,channelWidthMHz,rssi,locationLabel,observedAt,notes'
-                value={csvInput}
-                onChange={(event) => setCsvInput(event.currentTarget.value)}
-              />
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void handleCsvImport();
+                }}
+              >
+                <Stack gap='md'>
+                  <csvForm.Field name='csvInput'>
+                    {(field) => (
+                      <Textarea
+                        label='CSV'
+                        minRows={10}
+                        placeholder='source,ssid,bssid,band,channel,channelWidthMHz,rssi,locationLabel,observedAt,notes'
+                        value={field.state.value}
+                        onChange={(event) => {
+                          setObservedWifiError(null);
+                          setCsvErrors([]);
+                          field.handleChange(event.currentTarget.value);
+                        }}
+                      />
+                    )}
+                  </csvForm.Field>
 
-              {csvErrors.length > 0 ? (
-                <Alert color='red' title='CSV バリデーション'>
-                  {csvErrors.map((error) => (
-                    <Text key={`${error.row}-${error.message}`}>{error.message}</Text>
-                  ))}
-                </Alert>
-              ) : (
-                <Alert color='blue' variant='light'>
-                  一括登録は all-or-nothing です。1 行でも無効なら登録しません。
-                </Alert>
-              )}
+                  {csvErrors.length > 0 ? (
+                    <Alert color='red' title='CSV バリデーション'>
+                      {csvErrors.map((error) => (
+                        <Text key={`${error.row}-${error.message}`}>{error.message}</Text>
+                      ))}
+                    </Alert>
+                  ) : (
+                    <Alert color='blue' variant='light'>
+                      一括登録は all-or-nothing です。1 行でも無効なら登録しません。
+                    </Alert>
+                  )}
 
-              <Group justify='flex-end'>
-                <Button
-                  loading={bulkCreateObservedWifiMutation.isPending}
-                  onClick={() => void handleCsvImport()}
-                >
-                  CSV を一括登録
-                </Button>
-              </Group>
+                  <Group justify='flex-end'>
+                    <Button type='submit' loading={bulkCreateObservedWifiMutation.isPending}>
+                      CSV を一括登録
+                    </Button>
+                  </Group>
+                </Stack>
+              </form>
             </Stack>
           </Card>
         </Grid.Col>
@@ -787,7 +921,9 @@ export function AppDashboardPage() {
                     variant='subtle'
                     onClick={() => {
                       setEditingNoticeId(null);
-                      setNoticeValues(buildNoticeInitialValues());
+                      setNoticeFieldErrors({});
+                      setNoticeError(null);
+                      noticeForm.reset(buildNoticeInitialValues());
                     }}
                   >
                     新規に戻す
@@ -797,77 +933,112 @@ export function AppDashboardPage() {
 
               {noticeError ? <Alert color='red'>{noticeError}</Alert> : null}
 
-              <TextInput
-                label='title'
-                value={noticeValues.title}
-                onChange={(event) =>
-                  setNoticeValues((current) => ({
-                    ...current,
-                    title: event.currentTarget.value,
-                  }))
-                }
-              />
-              <Textarea
-                label='body'
-                minRows={4}
-                value={noticeValues.body}
-                onChange={(event) =>
-                  setNoticeValues((current) => ({
-                    ...current,
-                    body: event.currentTarget.value,
-                  }))
-                }
-              />
-              <Grid>
-                <Grid.Col span={{ base: 12, md: 4 }}>
-                  <NativeSelect
-                    label='severity'
-                    data={['info', 'warning', 'critical']}
-                    value={noticeValues.severity}
-                    onChange={(event) =>
-                      setNoticeValues((current) => ({
-                        ...current,
-                        severity: event.currentTarget.value as NoticeFormValues['severity'],
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 4 }}>
-                  <TextInput
-                    label='published at'
-                    type='datetime-local'
-                    value={noticeValues.publishedAt}
-                    onChange={(event) =>
-                      setNoticeValues((current) => ({
-                        ...current,
-                        publishedAt: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 4 }}>
-                  <TextInput
-                    label='expires at'
-                    type='datetime-local'
-                    value={noticeValues.expiresAt}
-                    onChange={(event) =>
-                      setNoticeValues((current) => ({
-                        ...current,
-                        expiresAt: event.currentTarget.value,
-                      }))
-                    }
-                  />
-                </Grid.Col>
-              </Grid>
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void handleNoticeSubmit();
+                }}
+              >
+                <Stack gap='md'>
+                  <noticeForm.Field name='title'>
+                    {(field) => (
+                      <TextInput
+                        label='title'
+                        value={field.state.value}
+                        onChange={(event) => {
+                          setNoticeError(null);
+                          setNoticeFieldErrors({});
+                          noticeZodForm.getChangeHandler(field.handleChange)(
+                            event.currentTarget.value,
+                          );
+                        }}
+                        error={noticeFieldErrors.title}
+                      />
+                    )}
+                  </noticeForm.Field>
+                  <noticeForm.Field name='body'>
+                    {(field) => (
+                      <Textarea
+                        label='body'
+                        minRows={4}
+                        value={field.state.value}
+                        onChange={(event) => {
+                          setNoticeError(null);
+                          setNoticeFieldErrors({});
+                          noticeZodForm.getChangeHandler(field.handleChange)(
+                            event.currentTarget.value,
+                          );
+                        }}
+                        error={noticeFieldErrors.body}
+                      />
+                    )}
+                  </noticeForm.Field>
+                  <Grid>
+                    <Grid.Col span={{ base: 12, md: 4 }}>
+                      <noticeForm.Field name='severity'>
+                        {(field) => (
+                          <NativeSelect
+                            label='severity'
+                            data={['info', 'warning', 'critical']}
+                            value={field.state.value}
+                            onChange={(event) => {
+                              setNoticeError(null);
+                              setNoticeFieldErrors({});
+                              noticeZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value as NoticeFormValues['severity'],
+                              );
+                            }}
+                          />
+                        )}
+                      </noticeForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 4 }}>
+                      <noticeForm.Field name='publishedAt'>
+                        {(field) => (
+                          <TextInput
+                            label='published at'
+                            type='datetime-local'
+                            value={field.state.value}
+                            onChange={(event) => {
+                              setNoticeError(null);
+                              setNoticeFieldErrors({});
+                              field.handleChange(event.currentTarget.value);
+                            }}
+                            error={noticeFieldErrors.publishedAt}
+                          />
+                        )}
+                      </noticeForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 4 }}>
+                      <noticeForm.Field name='expiresAt'>
+                        {(field) => (
+                          <TextInput
+                            label='expires at'
+                            type='datetime-local'
+                            value={field.state.value}
+                            onChange={(event) => {
+                              setNoticeError(null);
+                              setNoticeFieldErrors({});
+                              field.handleChange(event.currentTarget.value);
+                            }}
+                            error={noticeFieldErrors.expiresAt}
+                          />
+                        )}
+                      </noticeForm.Field>
+                    </Grid.Col>
+                  </Grid>
 
-              <Group justify='flex-end'>
-                <Button
-                  loading={createNoticeMutation.isPending || updateNoticeMutation.isPending}
-                  onClick={() => void handleNoticeSubmit()}
-                >
-                  {editingNoticeId ? 'お知らせを更新' : 'お知らせを作成'}
-                </Button>
-              </Group>
+                  <Group justify='flex-end'>
+                    <Button
+                      type='submit'
+                      loading={createNoticeMutation.isPending || updateNoticeMutation.isPending}
+                    >
+                      {editingNoticeId ? 'お知らせを更新' : 'お知らせを作成'}
+                    </Button>
+                  </Group>
+                </Stack>
+              </form>
 
               <Divider />
 

--- a/apps/web/src/routes/AppDashboardPage.tsx
+++ b/apps/web/src/routes/AppDashboardPage.tsx
@@ -318,6 +318,7 @@ export function AppDashboardPage() {
   const [selectedTournamentId, setSelectedTournamentId] = useState('');
   const [selectedTeamId, setSelectedTeamId] = useState('');
   const [csvErrors, setCsvErrors] = useState<Array<{ row: number; message: string }>>([]);
+  const [csvSubmitError, setCsvSubmitError] = useState<string | null>(null);
   const [observedWifiError, setObservedWifiError] = useState<string | null>(null);
   const [editingNoticeId, setEditingNoticeId] = useState<string | null>(null);
   const [noticeError, setNoticeError] = useState<string | null>(null);
@@ -332,7 +333,7 @@ export function AppDashboardPage() {
   );
   const csvZodForm = createTanStackFormZodHelpers(
     CsvImportFormSchema,
-    setObservedWifiError,
+    setCsvSubmitError,
     'CSV 取込に失敗しました',
   );
   const noticeZodForm = createTanStackFormZodHelpers(
@@ -395,16 +396,18 @@ export function AppDashboardPage() {
       csvZodForm.clearSubmitError();
 
       if (!selectedTournamentId) {
-        setObservedWifiError('大会を選択してください');
+        setCsvSubmitError('大会を選択してください');
         return;
       }
 
       const parsed = parseObservedWifiCsv(value.csvInput);
       if (parsed.errors.length > 0) {
+        setCsvSubmitError(null);
         setCsvErrors(parsed.errors);
         return;
       }
 
+      setCsvSubmitError(null);
       setCsvErrors([]);
 
       try {
@@ -955,6 +958,8 @@ export function AppDashboardPage() {
                 }}
               >
                 <Stack gap='md'>
+                  {csvSubmitError ? <Alert color='red'>{csvSubmitError}</Alert> : null}
+
                   <csvForm.Field
                     name='csvInput'
                     validators={{

--- a/apps/web/src/routes/AppDashboardPage.tsx
+++ b/apps/web/src/routes/AppDashboardPage.tsx
@@ -19,8 +19,17 @@ import { notifications } from '@mantine/notifications';
 import { useForm } from '@tanstack/react-form';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import { CreateNoticeSchema, CreateObservedWifiSchema } from '@wifiman/shared';
+import {
+  BANDS,
+  CreateNoticeSchema,
+  CreateObservedWifiSchema,
+  NOTICE_SEVERITIES,
+  OBSERVED_WIFI_SOURCES,
+  isValidChannel,
+  isValidChannelWidth,
+} from '@wifiman/shared';
 import { useEffect, useMemo, useState } from 'react';
+import { z } from 'zod';
 import {
   ApiClientError,
   apiQueryKeys,
@@ -30,7 +39,10 @@ import {
   type ObservedWifiCreateInput,
 } from '../lib/api/client.js';
 import { getSyncOverview } from '../lib/db/appDb.js';
-import { createTanStackFormZodHelpers } from '../lib/tanstackFormZod.js';
+import {
+  createTanStackFormZodHelpers,
+  toGlobalFormValidationError,
+} from '../lib/tanstackFormZod.js';
 import { parseObservedWifiCsv } from '../lib/teamManagement.js';
 import {
   useBulkCreateObservedWifiMutation,
@@ -80,6 +92,71 @@ type ObservedWifiDraft = {
   observedAt: string;
   notes?: string | null | undefined;
 };
+
+const DateTimeLocalStringSchema = z
+  .string()
+  .min(1)
+  .refine((value) => !Number.isNaN(new Date(value).getTime()), 'Invalid datetime');
+
+const OptionalDateTimeLocalStringSchema = z
+  .string()
+  .refine(
+    (value) => value.trim().length === 0 || !Number.isNaN(new Date(value).getTime()),
+    'Invalid datetime',
+  );
+
+const ObservedWifiFormSchema = z.object({
+  source: z.enum(OBSERVED_WIFI_SOURCES),
+  ssid: z.string().max(32),
+  bssid: z
+    .string()
+    .refine(
+      (value) => value.trim().length === 0 || /^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/.test(value),
+      'Invalid',
+    ),
+  band: z.enum(BANDS),
+  channel: z.string(),
+  channelWidthMHz: z.string(),
+  rssi: z.string(),
+  locationLabel: z.string().max(200),
+  observedAt: DateTimeLocalStringSchema,
+  notes: z.string().max(2000),
+});
+
+const CsvImportFormSchema = z.object({
+  csvInput: z.string().trim().min(1, 'CSV を入力してください'),
+});
+
+const NoticeFormSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  body: z.string().trim().min(1).max(5000),
+  severity: z.enum(NOTICE_SEVERITIES),
+  publishedAt: DateTimeLocalStringSchema,
+  expiresAt: OptionalDateTimeLocalStringSchema,
+});
+
+const ObservedWifiSubmitSchema = CreateObservedWifiSchema.omit({ tournamentId: true });
+const NoticeSubmitSchema = CreateNoticeSchema.omit({ tournamentId: true });
+
+function mapIssuesToFieldErrors<TFieldName extends string>(
+  error: z.ZodError,
+): Partial<Record<TFieldName, string>> {
+  const errors: Partial<Record<TFieldName, string>> = {};
+
+  for (const issue of error.issues) {
+    const field = issue.path[0];
+    if (typeof field === 'string' && !(field in errors)) {
+      errors[field as TFieldName] = issue.message;
+    }
+  }
+
+  return errors;
+}
+
+function normalizeOptionalString(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
 
 function toDateTimeLocalValue(value: string) {
   return value.slice(0, 16);
@@ -157,32 +234,53 @@ function parseObservedWifiFormValues(values: ObservedWifiFormValues): {
   data?: ObservedWifiDraft;
   errors: Partial<Record<keyof ObservedWifiFormValues, string>>;
 } {
-  const parsed = CreateObservedWifiSchema.omit({ tournamentId: true }).safeParse({
-    source: values.source,
-    ssid: values.ssid.trim() || null,
-    bssid: values.bssid.trim() || null,
-    band: values.band,
-    channel: Number(values.channel),
-    channelWidthMHz: values.channelWidthMHz.trim() ? Number(values.channelWidthMHz) : null,
-    rssi: values.rssi.trim() ? Number(values.rssi) : null,
-    locationLabel: values.locationLabel.trim() || null,
-    observedAt: new Date(values.observedAt).toISOString(),
-    notes: values.notes.trim() || null,
+  const rawParsed = ObservedWifiFormSchema.safeParse(values);
+
+  if (!rawParsed.success) {
+    return {
+      errors: mapIssuesToFieldErrors<keyof ObservedWifiFormValues & string>(rawParsed.error),
+    };
+  }
+
+  const parsed = ObservedWifiSubmitSchema.safeParse({
+    source: rawParsed.data.source,
+    ssid: normalizeOptionalString(rawParsed.data.ssid),
+    bssid: normalizeOptionalString(rawParsed.data.bssid),
+    band: rawParsed.data.band,
+    channel: Number(rawParsed.data.channel),
+    channelWidthMHz: rawParsed.data.channelWidthMHz.trim()
+      ? Number(rawParsed.data.channelWidthMHz)
+      : null,
+    rssi: rawParsed.data.rssi.trim() ? Number(rawParsed.data.rssi) : null,
+    locationLabel: normalizeOptionalString(rawParsed.data.locationLabel),
+    observedAt: new Date(rawParsed.data.observedAt).toISOString(),
+    notes: normalizeOptionalString(rawParsed.data.notes),
   });
 
-  if (parsed.success) {
-    return { data: parsed.data, errors: {} };
+  if (!parsed.success) {
+    return {
+      errors: mapIssuesToFieldErrors<keyof ObservedWifiFormValues & string>(parsed.error),
+    };
   }
 
   const errors: Partial<Record<keyof ObservedWifiFormValues, string>> = {};
-  for (const issue of parsed.error.issues) {
-    const field = issue.path[0];
-    if (typeof field === 'string' && !(field in errors)) {
-      errors[field as keyof ObservedWifiFormValues] = issue.message;
-    }
+
+  if (!isValidChannel(parsed.data.band, parsed.data.channel)) {
+    errors.channel = `帯域 ${parsed.data.band} に対してチャンネル ${parsed.data.channel} は無効です`;
   }
 
-  return { errors };
+  if (
+    parsed.data.channelWidthMHz != null &&
+    !isValidChannelWidth(parsed.data.band, parsed.data.channelWidthMHz as 20 | 40 | 80 | 160)
+  ) {
+    errors.channelWidthMHz = `帯域 ${parsed.data.band} に対してチャンネル幅 ${parsed.data.channelWidthMHz}MHz は無効です`;
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { errors };
+  }
+
+  return { data: parsed.data, errors: {} };
 }
 
 function parseNoticeFormValues(values: NoticeFormValues): {
@@ -190,23 +288,25 @@ function parseNoticeFormValues(values: NoticeFormValues): {
   updateInput?: NoticeUpdateInput;
   errors: Partial<Record<keyof NoticeFormValues, string>>;
 } {
-  const createInput = toNoticeCreateInput(values);
-  const updateInput = toNoticeUpdateInput(values);
-  const parsed = CreateNoticeSchema.omit({ tournamentId: true }).safeParse(createInput);
+  const rawParsed = NoticeFormSchema.safeParse(values);
 
-  if (parsed.success) {
-    return { createInput, updateInput, errors: {} };
+  if (!rawParsed.success) {
+    return {
+      errors: mapIssuesToFieldErrors<keyof NoticeFormValues & string>(rawParsed.error),
+    };
   }
 
-  const errors: Partial<Record<keyof NoticeFormValues, string>> = {};
-  for (const issue of parsed.error.issues) {
-    const field = issue.path[0];
-    if (typeof field === 'string' && !(field in errors)) {
-      errors[field as keyof NoticeFormValues] = issue.message;
-    }
+  const createInput = toNoticeCreateInput(rawParsed.data);
+  const updateInput = toNoticeUpdateInput(rawParsed.data);
+  const parsed = NoticeSubmitSchema.safeParse(createInput);
+
+  if (!parsed.success) {
+    return {
+      errors: mapIssuesToFieldErrors<keyof NoticeFormValues & string>(parsed.error),
+    };
   }
 
-  return { errors };
+  return { createInput, updateInput, errors: {} };
 }
 
 export function AppDashboardPage() {
@@ -215,31 +315,171 @@ export function AppDashboardPage() {
     queryKey: apiQueryKeys.syncOverview,
     queryFn: getSyncOverview,
   });
-  const observedWifiZodForm = createTanStackFormZodHelpers(CreateObservedWifiSchema);
-  const noticeZodForm = createTanStackFormZodHelpers(CreateNoticeSchema);
   const [selectedTournamentId, setSelectedTournamentId] = useState('');
   const [selectedTeamId, setSelectedTeamId] = useState('');
+  const [csvErrors, setCsvErrors] = useState<Array<{ row: number; message: string }>>([]);
+  const [observedWifiError, setObservedWifiError] = useState<string | null>(null);
+  const [editingNoticeId, setEditingNoticeId] = useState<string | null>(null);
+  const [noticeError, setNoticeError] = useState<string | null>(null);
+  const createObservedWifiMutation = useCreateObservedWifiMutation(selectedTournamentId);
+  const bulkCreateObservedWifiMutation = useBulkCreateObservedWifiMutation(selectedTournamentId);
+  const createNoticeMutation = useCreateTournamentNoticeMutation(selectedTournamentId);
+  const updateNoticeMutation = useUpdateNoticeMutation(selectedTournamentId);
+  const observedWifiZodForm = createTanStackFormZodHelpers(
+    ObservedWifiFormSchema,
+    setObservedWifiError,
+    '登録に失敗しました',
+  );
+  const csvZodForm = createTanStackFormZodHelpers(
+    CsvImportFormSchema,
+    setObservedWifiError,
+    'CSV 取込に失敗しました',
+  );
+  const noticeZodForm = createTanStackFormZodHelpers(
+    NoticeFormSchema,
+    setNoticeError,
+    'お知らせ保存に失敗しました',
+  );
   const observedWifiForm = useForm({
     defaultValues: buildObservedWifiInitialValues(),
+    validators: {
+      onSubmit: ({ value }) =>
+        toGlobalFormValidationError<ObservedWifiFormValues>(
+          parseObservedWifiFormValues(value).errors,
+        ),
+    },
+    onSubmit: async ({ value }) => {
+      observedWifiZodForm.clearSubmitError();
+
+      if (!selectedTournamentId) {
+        setObservedWifiError('大会を選択してください');
+        return;
+      }
+
+      const parsed = parseObservedWifiFormValues(value);
+      if (!parsed.data) {
+        return;
+      }
+
+      try {
+        await createObservedWifiMutation.mutateAsync(toObservedWifiInput(parsed.data));
+        observedWifiForm.reset(buildObservedWifiInitialValues());
+        notifications.show({
+          color: 'teal',
+          title: '野良 WiFi を登録しました',
+          message: 'チャンネルマップ反映用データを更新しました。',
+        });
+      } catch (error) {
+        observedWifiZodForm.handleSubmitError(error);
+      }
+    },
   });
   const csvForm = useForm({
     defaultValues: {
       csvInput: '',
     },
+    validators: {
+      onSubmit: ({ value }) => {
+        const parsed = CsvImportFormSchema.safeParse(value);
+
+        if (parsed.success) {
+          return undefined;
+        }
+
+        return toGlobalFormValidationError<{ csvInput: string }>({
+          csvInput: parsed.error.issues[0]?.message ?? 'CSV を入力してください',
+        });
+      },
+    },
+    onSubmit: async ({ value }) => {
+      csvZodForm.clearSubmitError();
+
+      if (!selectedTournamentId) {
+        setObservedWifiError('大会を選択してください');
+        return;
+      }
+
+      const parsed = parseObservedWifiCsv(value.csvInput);
+      if (parsed.errors.length > 0) {
+        setCsvErrors(parsed.errors);
+        return;
+      }
+
+      setCsvErrors([]);
+
+      try {
+        const result = await bulkCreateObservedWifiMutation.mutateAsync({
+          items: parsed.items.map((item) => ({
+            ...toObservedWifiInput(item),
+            tournamentId: selectedTournamentId,
+          })),
+        } satisfies ObservedWifiBulkCreateInput);
+
+        notifications.show({
+          color: 'teal',
+          title: 'CSV を一括登録しました',
+          message: `${result.count} 件を all-or-nothing で登録しました。`,
+        });
+        csvForm.reset({ csvInput: '' });
+      } catch (error) {
+        if (error instanceof ApiClientError) {
+          const details = (
+            error.payload as {
+              error?: { details?: { errors?: Array<{ row: number; message: string }> } };
+            }
+          )?.error?.details;
+          const serverErrors = details?.errors ?? [];
+          if (serverErrors.length > 0) {
+            setCsvErrors(serverErrors);
+            return;
+          }
+        }
+
+        csvZodForm.handleSubmitError(error);
+      }
+    },
   });
   const noticeForm = useForm({
     defaultValues: buildNoticeInitialValues(),
+    validators: {
+      onSubmit: ({ value }) =>
+        toGlobalFormValidationError<NoticeFormValues>(parseNoticeFormValues(value).errors),
+    },
+    onSubmit: async ({ value }) => {
+      noticeZodForm.clearSubmitError();
+
+      if (!selectedTournamentId) {
+        setNoticeError('大会を選択してください');
+        return;
+      }
+
+      const parsed = parseNoticeFormValues(value);
+      if (!parsed.createInput || !parsed.updateInput) {
+        return;
+      }
+
+      try {
+        if (editingNoticeId) {
+          await updateNoticeMutation.mutateAsync({
+            id: editingNoticeId,
+            input: parsed.updateInput,
+          });
+        } else {
+          await createNoticeMutation.mutateAsync(parsed.createInput);
+        }
+
+        notifications.show({
+          color: 'teal',
+          title: editingNoticeId ? 'お知らせを更新しました' : 'お知らせを作成しました',
+          message: '大会トップの notices を更新しました。',
+        });
+        setEditingNoticeId(null);
+        noticeForm.reset(buildNoticeInitialValues());
+      } catch (error) {
+        noticeZodForm.handleSubmitError(error);
+      }
+    },
   });
-  const [observedWifiFieldErrors, setObservedWifiFieldErrors] = useState<
-    Partial<Record<keyof ObservedWifiFormValues, string>>
-  >({});
-  const [csvErrors, setCsvErrors] = useState<Array<{ row: number; message: string }>>([]);
-  const [observedWifiError, setObservedWifiError] = useState<string | null>(null);
-  const [editingNoticeId, setEditingNoticeId] = useState<string | null>(null);
-  const [noticeFieldErrors, setNoticeFieldErrors] = useState<
-    Partial<Record<keyof NoticeFormValues, string>>
-  >({});
-  const [noticeError, setNoticeError] = useState<string | null>(null);
 
   useEffect(() => {
     if (selectedTournamentId || (tournamentsQuery.data?.length ?? 0) === 0) {
@@ -273,10 +513,6 @@ export function AppDashboardPage() {
     setSelectedTeamId(teams[0]?.id ?? '');
   }, [selectedTeamId, teamsQuery.data]);
 
-  const createObservedWifiMutation = useCreateObservedWifiMutation(selectedTournamentId);
-  const bulkCreateObservedWifiMutation = useBulkCreateObservedWifiMutation(selectedTournamentId);
-  const createNoticeMutation = useCreateTournamentNoticeMutation(selectedTournamentId);
-  const updateNoticeMutation = useUpdateNoticeMutation(selectedTournamentId);
   const resendTeamAccessMutation = useResendTeamAccessMutation(selectedTeamId);
 
   const highSeverityReports = useMemo(() => {
@@ -305,122 +541,8 @@ export function AppDashboardPage() {
   const bandSummaryText = `2.4GHz ${bandSummary?.['2.4GHz'] ?? 0} / 5GHz ${bandSummary?.['5GHz'] ?? 0} / 6GHz ${bandSummary?.['6GHz'] ?? 0}`;
   const issueReportCount = issueReportsQuery.data?.length ?? 0;
 
-  const handleObservedWifiSubmit = async () => {
-    const values = observedWifiForm.state.values;
-    setObservedWifiError(null);
-    setObservedWifiFieldErrors({});
-
-    if (!selectedTournamentId) {
-      setObservedWifiError('大会を選択してください');
-      return;
-    }
-
-    const parsed = parseObservedWifiFormValues(values);
-    if (!parsed.data) {
-      setObservedWifiFieldErrors(parsed.errors);
-      return;
-    }
-
-    try {
-      await createObservedWifiMutation.mutateAsync(toObservedWifiInput(parsed.data));
-      observedWifiForm.reset(buildObservedWifiInitialValues());
-      notifications.show({
-        color: 'teal',
-        title: '野良 WiFi を登録しました',
-        message: 'チャンネルマップ反映用データを更新しました。',
-      });
-    } catch (error) {
-      setObservedWifiError(error instanceof Error ? error.message : '登録に失敗しました');
-    }
-  };
-
-  const handleCsvImport = async () => {
-    const csvInput = csvForm.state.values.csvInput;
-    setObservedWifiError(null);
-
-    if (!selectedTournamentId) {
-      setObservedWifiError('大会を選択してください');
-      return;
-    }
-
-    const parsed = parseObservedWifiCsv(csvInput);
-    if (parsed.errors.length > 0) {
-      setCsvErrors(parsed.errors);
-      return;
-    }
-
-    setCsvErrors([]);
-
-    try {
-      const result = await bulkCreateObservedWifiMutation.mutateAsync({
-        items: parsed.items.map((item) => ({
-          ...toObservedWifiInput(item),
-          tournamentId: selectedTournamentId,
-        })),
-      } satisfies ObservedWifiBulkCreateInput);
-
-      notifications.show({
-        color: 'teal',
-        title: 'CSV を一括登録しました',
-        message: `${result.count} 件を all-or-nothing で登録しました。`,
-      });
-      csvForm.reset({ csvInput: '' });
-    } catch (error) {
-      if (error instanceof ApiClientError) {
-        const details = (
-          error.payload as {
-            error?: { details?: { errors?: Array<{ row: number; message: string }> } };
-          }
-        )?.error?.details;
-        const serverErrors = details?.errors ?? [];
-        if (serverErrors.length > 0) {
-          setCsvErrors(serverErrors);
-          return;
-        }
-      }
-
-      setObservedWifiError(error instanceof Error ? error.message : 'CSV 取込に失敗しました');
-    }
-  };
-
-  const handleNoticeSubmit = async () => {
-    const values = noticeForm.state.values;
-    setNoticeError(null);
-    setNoticeFieldErrors({});
-
-    if (!selectedTournamentId) {
-      setNoticeError('大会を選択してください');
-      return;
-    }
-
-    const parsed = parseNoticeFormValues(values);
-    if (!parsed.createInput || !parsed.updateInput) {
-      setNoticeFieldErrors(parsed.errors);
-      return;
-    }
-
-    try {
-      if (editingNoticeId) {
-        await updateNoticeMutation.mutateAsync({ id: editingNoticeId, input: parsed.updateInput });
-      } else {
-        await createNoticeMutation.mutateAsync(parsed.createInput);
-      }
-
-      notifications.show({
-        color: 'teal',
-        title: editingNoticeId ? 'お知らせを更新しました' : 'お知らせを作成しました',
-        message: '大会トップの notices を更新しました。',
-      });
-      setEditingNoticeId(null);
-      noticeForm.reset(buildNoticeInitialValues());
-    } catch (error) {
-      setNoticeError(error instanceof Error ? error.message : 'お知らせ保存に失敗しました');
-    }
-  };
-
   const handleStartNoticeEdit = (notice: NonNullable<typeof noticesQuery.data>[number]) => {
     setEditingNoticeId(notice.id);
-    setNoticeFieldErrors({});
     setNoticeError(null);
     noticeForm.reset({
       title: notice.title,
@@ -571,206 +693,242 @@ export function AppDashboardPage() {
               </Alert>
 
               {observedWifiError ? <Alert color='red'>{observedWifiError}</Alert> : null}
+
               <form
                 onSubmit={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
-                  void handleObservedWifiSubmit();
+                  observedWifiZodForm.handleSubmitInvalid();
+                  void observedWifiForm.handleSubmit();
                 }}
               >
-                <observedWifiForm.Subscribe selector={(state) => state.values}>
-                  {(_values) => (
-                    <Stack gap='md'>
-                      <Grid>
-                        <Grid.Col span={{ base: 12, md: 6 }}>
-                          <observedWifiForm.Field name='source'>
-                            {(field) => (
-                              <NativeSelect
-                                label='source'
-                                data={[
-                                  { value: 'manual', label: 'manual' },
-                                  { value: 'wild', label: 'wild' },
-                                  { value: 'analyzer_import', label: 'analyzer_import' },
-                                ]}
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
-                                    event.currentTarget.value as ObservedWifiFormValues['source'],
-                                  );
-                                }}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, md: 6 }}>
-                          <observedWifiForm.Field name='ssid'>
-                            {(field) => (
-                              <TextInput
-                                label='SSID'
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
-                                    event.currentTarget.value,
-                                  );
-                                }}
-                                error={observedWifiFieldErrors.ssid}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, md: 6 }}>
-                          <observedWifiForm.Field name='bssid'>
-                            {(field) => (
-                              <TextInput
-                                label='BSSID'
-                                placeholder='00:11:22:33:44:55'
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
-                                    event.currentTarget.value,
-                                  );
-                                }}
-                                error={observedWifiFieldErrors.bssid}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, md: 3 }}>
-                          <observedWifiForm.Field name='band'>
-                            {(field) => (
-                              <NativeSelect
-                                label='帯域'
-                                data={['2.4GHz', '5GHz', '6GHz']}
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
-                                    event.currentTarget.value as ObservedWifiFormValues['band'],
-                                  );
-                                }}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, md: 3 }}>
-                          <observedWifiForm.Field name='channel'>
-                            {(field) => (
-                              <TextInput
-                                label='channel'
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  field.handleChange(event.currentTarget.value);
-                                }}
-                                error={observedWifiFieldErrors.channel}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, md: 3 }}>
-                          <observedWifiForm.Field name='channelWidthMHz'>
-                            {(field) => (
-                              <TextInput
-                                label='channel width MHz'
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  field.handleChange(event.currentTarget.value);
-                                }}
-                                error={observedWifiFieldErrors.channelWidthMHz}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, md: 3 }}>
-                          <observedWifiForm.Field name='rssi'>
-                            {(field) => (
-                              <TextInput
-                                label='RSSI'
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  field.handleChange(event.currentTarget.value);
-                                }}
-                                error={observedWifiFieldErrors.rssi}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, md: 6 }}>
-                          <observedWifiForm.Field name='locationLabel'>
-                            {(field) => (
-                              <TextInput
-                                label='location'
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
-                                    event.currentTarget.value,
-                                  );
-                                }}
-                                error={observedWifiFieldErrors.locationLabel}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, md: 6 }}>
-                          <observedWifiForm.Field name='observedAt'>
-                            {(field) => (
-                              <TextInput
-                                label='observed at'
-                                type='datetime-local'
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  field.handleChange(event.currentTarget.value);
-                                }}
-                                error={observedWifiFieldErrors.observedAt}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                        <Grid.Col span={12}>
-                          <observedWifiForm.Field name='notes'>
-                            {(field) => (
-                              <Textarea
-                                label='notes'
-                                minRows={3}
-                                value={field.state.value}
-                                onChange={(event) => {
-                                  setObservedWifiError(null);
-                                  setObservedWifiFieldErrors({});
-                                  observedWifiZodForm.getChangeHandler(field.handleChange)(
-                                    event.currentTarget.value,
-                                  );
-                                }}
-                                error={observedWifiFieldErrors.notes}
-                              />
-                            )}
-                          </observedWifiForm.Field>
-                        </Grid.Col>
-                      </Grid>
+                <Stack gap='md'>
+                  <Grid>
+                    <Grid.Col span={{ base: 12, md: 6 }}>
+                      <observedWifiForm.Field
+                        name='source'
+                        validators={{
+                          onSubmit: observedWifiZodForm.getFieldValidator('source'),
+                        }}
+                      >
+                        {(field) => (
+                          <NativeSelect
+                            label='source'
+                            data={[
+                              { value: 'manual', label: 'manual' },
+                              { value: 'wild', label: 'wild' },
+                              { value: 'analyzer_import', label: 'analyzer_import' },
+                            ]}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value as ObservedWifiFormValues['source'],
+                              );
+                            }}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 6 }}>
+                      <observedWifiForm.Field
+                        name='ssid'
+                        validators={{
+                          onChange: observedWifiZodForm.getFieldValidator('ssid'),
+                          onSubmit: observedWifiZodForm.getFieldValidator('ssid'),
+                        }}
+                      >
+                        {(field) => (
+                          <TextInput
+                            label='SSID'
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
+                            }}
+                            error={field.state.meta.errors[0]}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 6 }}>
+                      <observedWifiForm.Field
+                        name='bssid'
+                        validators={{
+                          onChange: observedWifiZodForm.getFieldValidator('bssid'),
+                          onSubmit: observedWifiZodForm.getFieldValidator('bssid'),
+                        }}
+                      >
+                        {(field) => (
+                          <TextInput
+                            label='BSSID'
+                            placeholder='00:11:22:33:44:55'
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
+                            }}
+                            error={field.state.meta.errors[0]}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 3 }}>
+                      <observedWifiForm.Field
+                        name='band'
+                        validators={{
+                          onSubmit: observedWifiZodForm.getFieldValidator('band'),
+                        }}
+                      >
+                        {(field) => (
+                          <NativeSelect
+                            label='帯域'
+                            data={['2.4GHz', '5GHz', '6GHz']}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value as ObservedWifiFormValues['band'],
+                              );
+                            }}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 3 }}>
+                      <observedWifiForm.Field name='channel'>
+                        {(field) => (
+                          <TextInput
+                            label='channel'
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
+                            }}
+                            error={field.state.meta.errors[0]}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 3 }}>
+                      <observedWifiForm.Field name='channelWidthMHz'>
+                        {(field) => (
+                          <TextInput
+                            label='channel width MHz'
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
+                            }}
+                            error={field.state.meta.errors[0]}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 3 }}>
+                      <observedWifiForm.Field name='rssi'>
+                        {(field) => (
+                          <TextInput
+                            label='RSSI'
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
+                            }}
+                            error={field.state.meta.errors[0]}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 6 }}>
+                      <observedWifiForm.Field
+                        name='locationLabel'
+                        validators={{
+                          onChange: observedWifiZodForm.getFieldValidator('locationLabel'),
+                          onSubmit: observedWifiZodForm.getFieldValidator('locationLabel'),
+                        }}
+                      >
+                        {(field) => (
+                          <TextInput
+                            label='location'
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
+                            }}
+                            error={field.state.meta.errors[0]}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 6 }}>
+                      <observedWifiForm.Field
+                        name='observedAt'
+                        validators={{
+                          onChange: observedWifiZodForm.getFieldValidator('observedAt'),
+                          onSubmit: observedWifiZodForm.getFieldValidator('observedAt'),
+                        }}
+                      >
+                        {(field) => (
+                          <TextInput
+                            label='observed at'
+                            type='datetime-local'
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
+                            }}
+                            error={field.state.meta.errors[0]}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                    <Grid.Col span={12}>
+                      <observedWifiForm.Field
+                        name='notes'
+                        validators={{
+                          onChange: observedWifiZodForm.getFieldValidator('notes'),
+                          onSubmit: observedWifiZodForm.getFieldValidator('notes'),
+                        }}
+                      >
+                        {(field) => (
+                          <Textarea
+                            label='notes'
+                            minRows={3}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              observedWifiZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
+                            }}
+                            error={field.state.meta.errors[0]}
+                          />
+                        )}
+                      </observedWifiForm.Field>
+                    </Grid.Col>
+                  </Grid>
 
-                      <Group justify='flex-end'>
-                        <Button type='submit' loading={createObservedWifiMutation.isPending}>
-                          野良 WiFi を登録
-                        </Button>
-                      </Group>
-                    </Stack>
-                  )}
-                </observedWifiForm.Subscribe>
+                  <Group justify='flex-end'>
+                    <Button type='submit' loading={createObservedWifiMutation.isPending}>
+                      野良 WiFi を登録
+                    </Button>
+                  </Group>
+                </Stack>
               </form>
             </Stack>
           </Card>
@@ -791,22 +949,33 @@ export function AppDashboardPage() {
                 onSubmit={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
-                  void handleCsvImport();
+                  csvZodForm.handleSubmitInvalid();
+                  setCsvErrors([]);
+                  void csvForm.handleSubmit();
                 }}
               >
                 <Stack gap='md'>
-                  <csvForm.Field name='csvInput'>
+                  <csvForm.Field
+                    name='csvInput'
+                    validators={{
+                      onChange: csvZodForm.getFieldValidator('csvInput'),
+                      onSubmit: csvZodForm.getFieldValidator('csvInput'),
+                    }}
+                  >
                     {(field) => (
                       <Textarea
                         label='CSV'
                         minRows={10}
                         placeholder='source,ssid,bssid,band,channel,channelWidthMHz,rssi,locationLabel,observedAt,notes'
                         value={field.state.value}
+                        onBlur={field.handleBlur}
                         onChange={(event) => {
-                          setObservedWifiError(null);
                           setCsvErrors([]);
-                          field.handleChange(event.currentTarget.value);
+                          csvZodForm.getChangeHandler(field.handleChange)(
+                            event.currentTarget.value,
+                          );
                         }}
+                        error={field.state.meta.errors[0]}
                       />
                     )}
                   </csvForm.Field>
@@ -921,7 +1090,6 @@ export function AppDashboardPage() {
                     variant='subtle'
                     onClick={() => {
                       setEditingNoticeId(null);
-                      setNoticeFieldErrors({});
                       setNoticeError(null);
                       noticeForm.reset(buildNoticeInitialValues());
                     }}
@@ -937,54 +1105,69 @@ export function AppDashboardPage() {
                 onSubmit={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
-                  void handleNoticeSubmit();
+                  noticeZodForm.handleSubmitInvalid();
+                  void noticeForm.handleSubmit();
                 }}
               >
                 <Stack gap='md'>
-                  <noticeForm.Field name='title'>
+                  <noticeForm.Field
+                    name='title'
+                    validators={{
+                      onChange: noticeZodForm.getFieldValidator('title'),
+                      onSubmit: noticeZodForm.getFieldValidator('title'),
+                    }}
+                  >
                     {(field) => (
                       <TextInput
                         label='title'
                         value={field.state.value}
+                        onBlur={field.handleBlur}
                         onChange={(event) => {
-                          setNoticeError(null);
-                          setNoticeFieldErrors({});
                           noticeZodForm.getChangeHandler(field.handleChange)(
                             event.currentTarget.value,
                           );
                         }}
-                        error={noticeFieldErrors.title}
+                        error={field.state.meta.errors[0]}
                       />
                     )}
                   </noticeForm.Field>
-                  <noticeForm.Field name='body'>
+                  <noticeForm.Field
+                    name='body'
+                    validators={{
+                      onChange: noticeZodForm.getFieldValidator('body'),
+                      onSubmit: noticeZodForm.getFieldValidator('body'),
+                    }}
+                  >
                     {(field) => (
                       <Textarea
                         label='body'
                         minRows={4}
                         value={field.state.value}
+                        onBlur={field.handleBlur}
                         onChange={(event) => {
-                          setNoticeError(null);
-                          setNoticeFieldErrors({});
                           noticeZodForm.getChangeHandler(field.handleChange)(
                             event.currentTarget.value,
                           );
                         }}
-                        error={noticeFieldErrors.body}
+                        error={field.state.meta.errors[0]}
                       />
                     )}
                   </noticeForm.Field>
                   <Grid>
                     <Grid.Col span={{ base: 12, md: 4 }}>
-                      <noticeForm.Field name='severity'>
+                      <noticeForm.Field
+                        name='severity'
+                        validators={{
+                          onSubmit: noticeZodForm.getFieldValidator('severity'),
+                        }}
+                      >
                         {(field) => (
                           <NativeSelect
                             label='severity'
                             data={['info', 'warning', 'critical']}
                             value={field.state.value}
+                            onBlur={field.handleBlur}
                             onChange={(event) => {
-                              setNoticeError(null);
-                              setNoticeFieldErrors({});
                               noticeZodForm.getChangeHandler(field.handleChange)(
                                 event.currentTarget.value as NoticeFormValues['severity'],
                               );
@@ -994,35 +1177,49 @@ export function AppDashboardPage() {
                       </noticeForm.Field>
                     </Grid.Col>
                     <Grid.Col span={{ base: 12, md: 4 }}>
-                      <noticeForm.Field name='publishedAt'>
+                      <noticeForm.Field
+                        name='publishedAt'
+                        validators={{
+                          onChange: noticeZodForm.getFieldValidator('publishedAt'),
+                          onSubmit: noticeZodForm.getFieldValidator('publishedAt'),
+                        }}
+                      >
                         {(field) => (
                           <TextInput
                             label='published at'
                             type='datetime-local'
                             value={field.state.value}
+                            onBlur={field.handleBlur}
                             onChange={(event) => {
-                              setNoticeError(null);
-                              setNoticeFieldErrors({});
-                              field.handleChange(event.currentTarget.value);
+                              noticeZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
                             }}
-                            error={noticeFieldErrors.publishedAt}
+                            error={field.state.meta.errors[0]}
                           />
                         )}
                       </noticeForm.Field>
                     </Grid.Col>
                     <Grid.Col span={{ base: 12, md: 4 }}>
-                      <noticeForm.Field name='expiresAt'>
+                      <noticeForm.Field
+                        name='expiresAt'
+                        validators={{
+                          onChange: noticeZodForm.getFieldValidator('expiresAt'),
+                          onSubmit: noticeZodForm.getFieldValidator('expiresAt'),
+                        }}
+                      >
                         {(field) => (
                           <TextInput
                             label='expires at'
                             type='datetime-local'
                             value={field.state.value}
+                            onBlur={field.handleBlur}
                             onChange={(event) => {
-                              setNoticeError(null);
-                              setNoticeFieldErrors({});
-                              field.handleChange(event.currentTarget.value);
+                              noticeZodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
                             }}
-                            error={noticeFieldErrors.expiresAt}
+                            error={field.state.meta.errors[0]}
                           />
                         )}
                       </noticeForm.Field>

--- a/apps/web/src/routes/TeamDetailPage.tsx
+++ b/apps/web/src/routes/TeamDetailPage.tsx
@@ -17,6 +17,7 @@ import {
   Title,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
+import { useForm } from '@tanstack/react-form';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
@@ -42,17 +43,24 @@ import type {
 import { canEditTeamResources, canViewTeamPrivateFields, isOwnTeam } from '../lib/authz.js';
 import { listIssueReportSyncRecords } from '../lib/db/appDb.js';
 import {
+  createTanStackFormZodHelpers,
+  toGlobalFormValidationError,
+} from '../lib/tanstackFormZod.js';
+import {
   buildDeviceSpecFormValues,
   buildTeamFormValues,
   buildWifiConfigFormValues,
   countActiveWifiConfigs,
+  DeviceSpecEditorSchema,
   type DeviceSpecFormValues,
   findRelevantBestPractices,
   getBandOptions,
   parseDeviceSpecFormValues,
   parseTeamFormValues,
   parseWifiConfigFormValues,
+  TeamEditorSchema,
   type TeamFormValues,
+  WifiConfigEditorSchema,
   type WifiConfigFormValues,
 } from '../lib/teamManagement.js';
 import { useAuthSession } from '../lib/useAuthSession.js';
@@ -245,12 +253,26 @@ function TeamEditorSection({
   onSubmit,
   saving,
 }: TeamEditorProps) {
-  const [values, setValues] = useState<TeamFormValues>(() => buildTeamFormValues(team));
-  const [errors, setErrors] = useState<Record<string, string>>({});
+  const zodForm = createTanStackFormZodHelpers(TeamEditorSchema);
+  const form = useForm({
+    defaultValues: buildTeamFormValues(team),
+    validators: {
+      onSubmit: ({ value }) =>
+        toGlobalFormValidationError<TeamFormValues>(parseTeamFormValues(value).errors),
+    },
+    onSubmit: async ({ value }) => {
+      const parsed = parseTeamFormValues(value);
+      if (!parsed.data) {
+        return;
+      }
+
+      await onSubmit(value);
+    },
+  });
 
   useEffect(() => {
-    setValues(buildTeamFormValues(team));
-  }, [team]);
+    form.reset(buildTeamFormValues(team));
+  }, [form, team]);
 
   return (
     <Card className='feature-card' padding='lg' radius='xl'>
@@ -265,49 +287,75 @@ function TeamEditorSection({
         <form
           onSubmit={(event) => {
             event.preventDefault();
-            const parsed = parseTeamFormValues(values);
-            setErrors(parsed.errors);
-            if (!parsed.data) {
-              return;
-            }
-            void onSubmit(values);
+            event.stopPropagation();
+            void form.handleSubmit();
           }}
         >
           <Stack gap='md'>
-            <TextInput
-              label='チーム名'
-              value={values.name}
-              onChange={(event) =>
-                setValues((current) => ({ ...current, name: event.currentTarget.value }))
-              }
-              error={errors.name}
-              disabled={!canEdit}
-            />
+            <form.Field
+              name='name'
+              validators={{
+                onChange: zodForm.getFieldValidator('name'),
+                onSubmit: zodForm.getFieldValidator('name'),
+              }}
+            >
+              {(field) => (
+                <TextInput
+                  label='チーム名'
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) =>
+                    zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                  }
+                  error={field.state.meta.errors[0]}
+                  disabled={!canEdit}
+                />
+              )}
+            </form.Field>
             <Grid>
               <Grid.Col span={{ base: 12, md: 6 }}>
-                <TextInput
-                  label='学校・団体名'
-                  value={values.organization}
-                  onChange={(event) =>
-                    setValues((current) => ({
-                      ...current,
-                      organization: event.currentTarget.value,
-                    }))
-                  }
-                  error={errors.organization}
-                  disabled={!canEdit}
-                />
+                <form.Field
+                  name='organization'
+                  validators={{
+                    onChange: zodForm.getFieldValidator('organization'),
+                    onSubmit: zodForm.getFieldValidator('organization'),
+                  }}
+                >
+                  {(field) => (
+                    <TextInput
+                      label='学校・団体名'
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                      }
+                      error={field.state.meta.errors[0]}
+                      disabled={!canEdit}
+                    />
+                  )}
+                </form.Field>
               </Grid.Col>
               <Grid.Col span={{ base: 12, md: 6 }}>
-                <TextInput
-                  label='ピット番号'
-                  value={values.pitId}
-                  onChange={(event) =>
-                    setValues((current) => ({ ...current, pitId: event.currentTarget.value }))
-                  }
-                  error={errors.pitId}
-                  disabled={!canEdit}
-                />
+                <form.Field
+                  name='pitId'
+                  validators={{
+                    onChange: zodForm.getFieldValidator('pitId'),
+                    onSubmit: zodForm.getFieldValidator('pitId'),
+                  }}
+                >
+                  {(field) => (
+                    <TextInput
+                      label='ピット番号'
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                      }
+                      error={field.state.meta.errors[0]}
+                      disabled={!canEdit}
+                    />
+                  )}
+                </form.Field>
               </Grid.Col>
             </Grid>
 
@@ -315,45 +363,72 @@ function TeamEditorSection({
               <>
                 <Grid>
                   <Grid.Col span={{ base: 12, md: 6 }}>
-                    <TextInput
-                      label='代表メールアドレス'
-                      value={values.contactEmail}
-                      onChange={(event) =>
-                        setValues((current) => ({
-                          ...current,
-                          contactEmail: event.currentTarget.value,
-                        }))
-                      }
-                      error={errors.contactEmail}
-                      disabled={!canEdit}
-                    />
+                    <form.Field
+                      name='contactEmail'
+                      validators={{
+                        onChange: zodForm.getFieldValidator('contactEmail'),
+                        onSubmit: zodForm.getFieldValidator('contactEmail'),
+                      }}
+                    >
+                      {(field) => (
+                        <TextInput
+                          label='代表メールアドレス'
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                          }
+                          error={field.state.meta.errors[0]}
+                          disabled={!canEdit}
+                        />
+                      )}
+                    </form.Field>
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, md: 6 }}>
-                    <TextInput
-                      label='表示用連絡先名'
-                      value={values.displayContactName}
-                      onChange={(event) =>
-                        setValues((current) => ({
-                          ...current,
-                          displayContactName: event.currentTarget.value,
-                        }))
-                      }
-                      error={errors.displayContactName}
-                      disabled={!canEdit}
-                    />
+                    <form.Field
+                      name='displayContactName'
+                      validators={{
+                        onChange: zodForm.getFieldValidator('displayContactName'),
+                        onSubmit: zodForm.getFieldValidator('displayContactName'),
+                      }}
+                    >
+                      {(field) => (
+                        <TextInput
+                          label='表示用連絡先名'
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                          }
+                          error={field.state.meta.errors[0]}
+                          disabled={!canEdit}
+                        />
+                      )}
+                    </form.Field>
                   </Grid.Col>
                 </Grid>
 
-                <Textarea
-                  label='メモ'
-                  value={values.notes}
-                  onChange={(event) =>
-                    setValues((current) => ({ ...current, notes: event.currentTarget.value }))
-                  }
-                  error={errors.notes}
-                  minRows={4}
-                  disabled={!canEdit}
-                />
+                <form.Field
+                  name='notes'
+                  validators={{
+                    onChange: zodForm.getFieldValidator('notes'),
+                    onSubmit: zodForm.getFieldValidator('notes'),
+                  }}
+                >
+                  {(field) => (
+                    <Textarea
+                      label='メモ'
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                      }
+                      error={field.state.meta.errors[0]}
+                      minRows={4}
+                      disabled={!canEdit}
+                    />
+                  )}
+                </form.Field>
               </>
             ) : (
               <Alert color='gray' variant='light'>
@@ -362,11 +437,19 @@ function TeamEditorSection({
             )}
 
             {canEdit ? (
-              <Group justify='flex-end'>
-                <Button type='submit' loading={saving}>
-                  チーム情報を保存
-                </Button>
-              </Group>
+              <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+                {([canSubmit, isSubmitting]) => (
+                  <Group justify='flex-end'>
+                    <Button
+                      type='submit'
+                      disabled={!canSubmit}
+                      loading={saving || Boolean(isSubmitting)}
+                    >
+                      チーム情報を保存
+                    </Button>
+                  </Group>
+                )}
+              </form.Subscribe>
             ) : null}
           </Stack>
         </form>
@@ -386,47 +469,23 @@ function WifiConfigEditorSection({
   onSubmit,
   submitting,
 }: WifiEditorProps) {
-  const [values, setValues] = useState<WifiConfigFormValues>(initialValues);
-  const [errors, setErrors] = useState<Record<string, string>>({});
+  const zodForm = createTanStackFormZodHelpers(WifiConfigEditorSchema);
+  const [errors, setErrors] = useState<Partial<Record<keyof WifiConfigFormValues, string>>>({});
   const [formError, setFormError] = useState<string | null>(null);
+  const form = useForm({
+    defaultValues: initialValues,
+  });
 
   useEffect(() => {
-    setValues(initialValues);
+    form.reset(initialValues);
     setErrors({});
     setFormError(null);
-  }, [initialValues]);
+  }, [form, initialValues]);
 
-  const sameBandConfigs = useMemo(
-    () => configs.filter((config) => config.band === values.band && config.id !== editingId),
-    [configs, editingId, values.band],
-  );
-
-  const selectedDeviceSpecs = useMemo(
-    () =>
-      [values.apDeviceId, values.clientDeviceId]
-        .map((id) => deviceSpecs.find((spec) => spec.id === id))
-        .filter((spec): spec is DeviceSpecView => spec != null),
-    [deviceSpecs, values.apDeviceId, values.clientDeviceId],
-  );
-
-  const bestPracticeBodies = useMemo(
-    () =>
-      findRelevantBestPractices(
-        bestPractices,
-        values.band,
-        values.purpose,
-        selectedDeviceSpecs.map((spec) => spec.model),
-      ).map((practice) => practice.body),
-    [bestPractices, selectedDeviceSpecs, values.band, values.purpose],
-  );
-
-  const knownIssueSummaries = useMemo(
-    () =>
-      selectedDeviceSpecs
-        .filter((spec) => Boolean(spec.knownIssues))
-        .map((spec) => `${spec.model}: ${spec.knownIssues}`),
-    [selectedDeviceSpecs],
-  );
+  const clearValidationState = () => {
+    setErrors({});
+    setFormError(null);
+  };
 
   return (
     <Card className='feature-card' padding='lg' radius='xl'>
@@ -438,261 +497,372 @@ function WifiConfigEditorSection({
           </Button>
         </Group>
 
-        {formError ? (
-          <Alert color='red' variant='light'>
-            {formError}
-          </Alert>
-        ) : null}
-
         <form
-          onSubmit={(event) => {
+          onSubmit={async (event) => {
             event.preventDefault();
+            event.stopPropagation();
+            const values = form.state.values;
             const parsed = parseWifiConfigFormValues(
               values,
               configs.map((config) => ({ id: config.id, status: config.status })),
               editingId,
             );
+
             setErrors(parsed.errors);
             setFormError(parsed.formError ?? null);
             if (!parsed.data) {
               return;
             }
-            void onSubmit(values);
+
+            await onSubmit(values);
           }}
         >
-          <Stack gap='md'>
-            <Grid>
-              <Grid.Col span={{ base: 12, md: 6 }}>
-                <TextInput
-                  label='構成名'
-                  value={values.name}
-                  onChange={(event) =>
-                    setValues((current) => ({ ...current, name: event.currentTarget.value }))
-                  }
-                  error={errors.name}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-              <Grid.Col span={{ base: 12, md: 6 }}>
-                <Select
-                  label='用途'
-                  data={PURPOSES.map((value) => ({ value, label: value }))}
-                  value={values.purpose}
-                  onChange={(value) =>
-                    setValues((current) => ({
-                      ...current,
-                      purpose: (value ?? 'control') as WifiConfigFormValues['purpose'],
-                    }))
-                  }
-                  allowDeselect={false}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-            </Grid>
+          <form.Subscribe selector={(state) => state.values}>
+            {(values) => {
+              const sameBandConfigs = configs.filter(
+                (config) => config.band === values.band && config.id !== editingId,
+              );
+              const selectedDeviceSpecs = [values.apDeviceId, values.clientDeviceId]
+                .map((id) => deviceSpecs.find((spec) => spec.id === id))
+                .filter((spec): spec is DeviceSpecView => spec != null);
+              const bestPracticeBodies = findRelevantBestPractices(
+                bestPractices,
+                values.band,
+                values.purpose,
+                selectedDeviceSpecs.map((spec) => spec.model),
+              ).map((practice) => practice.body);
+              const knownIssueSummaries = selectedDeviceSpecs
+                .filter((spec) => Boolean(spec.knownIssues))
+                .map((spec) => `${spec.model}: ${spec.knownIssues}`);
 
-            <Grid>
-              <Grid.Col span={{ base: 12, md: 4 }}>
-                <Select
-                  label='帯域'
-                  data={getBandOptions().map((value) => ({ value, label: value }))}
-                  value={values.band}
-                  onChange={(value) =>
-                    setValues((current) => ({
-                      ...current,
-                      band: (value ?? '5GHz') as WifiConfigFormValues['band'],
-                    }))
-                  }
-                  allowDeselect={false}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-              <Grid.Col span={{ base: 12, md: 4 }}>
-                <TextInput
-                  label='チャンネル'
-                  value={values.channel}
-                  onChange={(event) =>
-                    setValues((current) => ({ ...current, channel: event.currentTarget.value }))
-                  }
-                  error={errors.channel}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-              <Grid.Col span={{ base: 12, md: 4 }}>
-                <Select
-                  label='幅 (MHz)'
-                  data={CHANNEL_WIDTHS.map((value) => ({
-                    value: String(value),
-                    label: `${value} MHz`,
-                  }))}
-                  value={values.channelWidthMHz}
-                  onChange={(value) =>
-                    setValues((current) => ({
-                      ...current,
-                      channelWidthMHz: value ?? String(CHANNEL_WIDTHS[0]),
-                    }))
-                  }
-                  error={errors.channelWidthMHz}
-                  allowDeselect={false}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-            </Grid>
+              return (
+                <Stack gap='md'>
+                  {formError ? (
+                    <Alert color='red' variant='light'>
+                      {formError}
+                    </Alert>
+                  ) : null}
 
-            <Grid>
-              <Grid.Col span={{ base: 12, md: 4 }}>
-                <Select
-                  label='役割'
-                  data={WIFI_CONFIG_ROLES.map((value) => ({ value, label: value }))}
-                  value={values.role}
-                  onChange={(value) =>
-                    setValues((current) => ({
-                      ...current,
-                      role: (value ?? 'primary') as WifiConfigFormValues['role'],
-                    }))
-                  }
-                  allowDeselect={false}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-              <Grid.Col span={{ base: 12, md: 4 }}>
-                <Select
-                  label='状態'
-                  data={WIFI_CONFIG_STATUSES.map((value) => ({ value, label: value }))}
-                  value={values.status}
-                  onChange={(value) =>
-                    setValues((current) => ({
-                      ...current,
-                      status: (value ?? 'active') as WifiConfigFormValues['status'],
-                    }))
-                  }
-                  allowDeselect={false}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-              <Grid.Col span={{ base: 12, md: 4 }}>
-                <Select
-                  label='想定距離'
-                  data={[
-                    { value: '', label: '未設定' },
-                    { value: 'near', label: 'near' },
-                    { value: 'mid', label: 'mid' },
-                    { value: 'far', label: 'far' },
-                  ]}
-                  value={values.expectedDistanceCategory}
-                  onChange={(value) =>
-                    setValues((current) => ({
-                      ...current,
-                      expectedDistanceCategory:
-                        value === null
-                          ? ''
-                          : (value as WifiConfigFormValues['expectedDistanceCategory']),
-                    }))
-                  }
-                  allowDeselect={false}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-            </Grid>
+                  <Grid>
+                    <Grid.Col span={{ base: 12, md: 6 }}>
+                      <form.Field
+                        name='name'
+                        validators={{
+                          onChange: zodForm.getFieldValidator('name'),
+                          onSubmit: zodForm.getFieldValidator('name'),
+                        }}
+                      >
+                        {(field) => (
+                          <TextInput
+                            label='構成名'
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              clearValidationState();
+                              zodForm.getChangeHandler(field.handleChange)(
+                                event.currentTarget.value,
+                              );
+                            }}
+                            error={field.state.meta.errors[0] ?? errors.name}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 6 }}>
+                      <form.Field name='purpose'>
+                        {(field) => (
+                          <Select
+                            label='用途'
+                            data={PURPOSES.map((value) => ({ value, label: value }))}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(value) => {
+                              clearValidationState();
+                              zodForm.getChangeHandler(field.handleChange)(
+                                (value ?? 'control') as WifiConfigFormValues['purpose'],
+                              );
+                            }}
+                            allowDeselect={false}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                  </Grid>
 
-            <Grid>
-              <Grid.Col span={{ base: 12, md: 6 }}>
-                <Select
-                  label='AP 機材'
-                  data={[
-                    { value: '', label: '未選択' },
-                    ...deviceSpecs.map((spec) => ({
-                      value: spec.id,
-                      label: `${spec.vendor ?? 'Unknown'} ${spec.model}`,
-                    })),
-                  ]}
-                  value={values.apDeviceId}
-                  onChange={(value) =>
-                    setValues((current) => ({ ...current, apDeviceId: value ?? '' }))
-                  }
-                  allowDeselect={false}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-              <Grid.Col span={{ base: 12, md: 6 }}>
-                <Select
-                  label='クライアント機材'
-                  data={[
-                    { value: '', label: '未選択' },
-                    ...deviceSpecs.map((spec) => ({
-                      value: spec.id,
-                      label: `${spec.vendor ?? 'Unknown'} ${spec.model}`,
-                    })),
-                  ]}
-                  value={values.clientDeviceId}
-                  onChange={(value) =>
-                    setValues((current) => ({ ...current, clientDeviceId: value ?? '' }))
-                  }
-                  allowDeselect={false}
-                  disabled={!canEdit}
-                />
-              </Grid.Col>
-            </Grid>
+                  <Grid>
+                    <Grid.Col span={{ base: 12, md: 4 }}>
+                      <form.Field name='band'>
+                        {(field) => (
+                          <Select
+                            label='帯域'
+                            data={getBandOptions().map((value) => ({ value, label: value }))}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(value) => {
+                              clearValidationState();
+                              zodForm.getChangeHandler(field.handleChange)(
+                                (value ?? '5GHz') as WifiConfigFormValues['band'],
+                              );
+                            }}
+                            allowDeselect={false}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 4 }}>
+                      <form.Field name='channel'>
+                        {(field) => (
+                          <TextInput
+                            label='チャンネル'
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              clearValidationState();
+                              field.handleChange(event.currentTarget.value);
+                            }}
+                            error={errors.channel}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 4 }}>
+                      <form.Field name='channelWidthMHz'>
+                        {(field) => (
+                          <Select
+                            label='幅 (MHz)'
+                            data={CHANNEL_WIDTHS.map((value) => ({
+                              value: String(value),
+                              label: `${value} MHz`,
+                            }))}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(value) => {
+                              clearValidationState();
+                              field.handleChange(value ?? String(CHANNEL_WIDTHS[0]));
+                            }}
+                            error={errors.channelWidthMHz}
+                            allowDeselect={false}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                  </Grid>
 
-            <TextInput
-              label='Ping 監視先 IP'
-              value={values.pingTargetIp}
-              onChange={(event) =>
-                setValues((current) => ({ ...current, pingTargetIp: event.currentTarget.value }))
-              }
-              error={errors.pingTargetIp}
-              disabled={!canEdit}
-            />
+                  <Grid>
+                    <Grid.Col span={{ base: 12, md: 4 }}>
+                      <form.Field name='role'>
+                        {(field) => (
+                          <Select
+                            label='役割'
+                            data={WIFI_CONFIG_ROLES.map((value) => ({ value, label: value }))}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(value) => {
+                              clearValidationState();
+                              zodForm.getChangeHandler(field.handleChange)(
+                                (value ?? 'primary') as WifiConfigFormValues['role'],
+                              );
+                            }}
+                            allowDeselect={false}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 4 }}>
+                      <form.Field name='status'>
+                        {(field) => (
+                          <Select
+                            label='状態'
+                            data={WIFI_CONFIG_STATUSES.map((value) => ({ value, label: value }))}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(value) => {
+                              clearValidationState();
+                              zodForm.getChangeHandler(field.handleChange)(
+                                (value ?? 'active') as WifiConfigFormValues['status'],
+                              );
+                            }}
+                            allowDeselect={false}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 4 }}>
+                      <form.Field name='expectedDistanceCategory'>
+                        {(field) => (
+                          <Select
+                            label='想定距離'
+                            data={[
+                              { value: '', label: '未設定' },
+                              { value: 'near', label: 'near' },
+                              { value: 'mid', label: 'mid' },
+                              { value: 'far', label: 'far' },
+                            ]}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(value) => {
+                              clearValidationState();
+                              zodForm.getChangeHandler(field.handleChange)(
+                                value === null
+                                  ? ''
+                                  : (value as WifiConfigFormValues['expectedDistanceCategory']),
+                              );
+                            }}
+                            allowDeselect={false}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                  </Grid>
 
-            <Textarea
-              label='メモ'
-              value={values.notes}
-              onChange={(event) =>
-                setValues((current) => ({ ...current, notes: event.currentTarget.value }))
-              }
-              error={errors.notes}
-              minRows={3}
-              disabled={!canEdit}
-            />
+                  <Grid>
+                    <Grid.Col span={{ base: 12, md: 6 }}>
+                      <form.Field name='apDeviceId'>
+                        {(field) => (
+                          <Select
+                            label='AP 機材'
+                            data={[
+                              { value: '', label: '未選択' },
+                              ...deviceSpecs.map((spec) => ({
+                                value: spec.id,
+                                label: `${spec.vendor ?? 'Unknown'} ${spec.model}`,
+                              })),
+                            ]}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(value) => {
+                              clearValidationState();
+                              zodForm.getChangeHandler(field.handleChange)(value ?? '');
+                            }}
+                            allowDeselect={false}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, md: 6 }}>
+                      <form.Field name='clientDeviceId'>
+                        {(field) => (
+                          <Select
+                            label='クライアント機材'
+                            data={[
+                              { value: '', label: '未選択' },
+                              ...deviceSpecs.map((spec) => ({
+                                value: spec.id,
+                                label: `${spec.vendor ?? 'Unknown'} ${spec.model}`,
+                              })),
+                            ]}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(value) => {
+                              clearValidationState();
+                              zodForm.getChangeHandler(field.handleChange)(value ?? '');
+                            }}
+                            allowDeselect={false}
+                            disabled={!canEdit}
+                          />
+                        )}
+                      </form.Field>
+                    </Grid.Col>
+                  </Grid>
 
-            <Alert color='blue' variant='light'>
-              同帯域の既存構成:{' '}
-              {sameBandConfigs.length === 0
-                ? 'なし'
-                : sameBandConfigs.map((config) => `${config.name} (${config.status})`).join(' / ')}
-            </Alert>
+                  <form.Field
+                    name='pingTargetIp'
+                    validators={{
+                      onChange: zodForm.getFieldValidator('pingTargetIp'),
+                      onSubmit: zodForm.getFieldValidator('pingTargetIp'),
+                    }}
+                  >
+                    {(field) => (
+                      <TextInput
+                        label='Ping 監視先 IP'
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          clearValidationState();
+                          zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value);
+                        }}
+                        error={field.state.meta.errors[0] ?? errors.pingTargetIp}
+                        disabled={!canEdit}
+                      />
+                    )}
+                  </form.Field>
 
-            {bestPracticeBodies.length > 0 ? (
-              <Alert color='teal' variant='light' title='関連ベストプラクティス'>
-                <Stack gap='xs'>
-                  {bestPracticeBodies.map((body) => (
-                    <Text key={body} size='sm'>
-                      {body}
-                    </Text>
-                  ))}
+                  <form.Field
+                    name='notes'
+                    validators={{
+                      onChange: zodForm.getFieldValidator('notes'),
+                      onSubmit: zodForm.getFieldValidator('notes'),
+                    }}
+                  >
+                    {(field) => (
+                      <Textarea
+                        label='メモ'
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          clearValidationState();
+                          zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value);
+                        }}
+                        error={field.state.meta.errors[0] ?? errors.notes}
+                        minRows={3}
+                        disabled={!canEdit}
+                      />
+                    )}
+                  </form.Field>
+
+                  <Alert color='blue' variant='light'>
+                    同帯域の既存構成:{' '}
+                    {sameBandConfigs.length === 0
+                      ? 'なし'
+                      : sameBandConfigs
+                          .map((config) => `${config.name} (${config.status})`)
+                          .join(' / ')}
+                  </Alert>
+
+                  {bestPracticeBodies.length > 0 ? (
+                    <Alert color='teal' variant='light' title='関連ベストプラクティス'>
+                      <Stack gap='xs'>
+                        {bestPracticeBodies.map((body) => (
+                          <Text key={body} size='sm'>
+                            {body}
+                          </Text>
+                        ))}
+                      </Stack>
+                    </Alert>
+                  ) : null}
+
+                  {knownIssueSummaries.length > 0 ? (
+                    <Alert color='orange' variant='light' title='関連機材の既知の注意点'>
+                      <Stack gap='xs'>
+                        {knownIssueSummaries.map((issue) => (
+                          <Text key={issue} size='sm'>
+                            {issue}
+                          </Text>
+                        ))}
+                      </Stack>
+                    </Alert>
+                  ) : null}
+
+                  {canEdit ? (
+                    <Group justify='flex-end'>
+                      <Button type='submit' loading={submitting}>
+                        保存
+                      </Button>
+                    </Group>
+                  ) : null}
                 </Stack>
-              </Alert>
-            ) : null}
-
-            {knownIssueSummaries.length > 0 ? (
-              <Alert color='orange' variant='light' title='関連機材の既知の注意点'>
-                <Stack gap='xs'>
-                  {knownIssueSummaries.map((issue) => (
-                    <Text key={issue} size='sm'>
-                      {issue}
-                    </Text>
-                  ))}
-                </Stack>
-              </Alert>
-            ) : null}
-
-            {canEdit ? (
-              <Group justify='flex-end'>
-                <Button type='submit' loading={submitting}>
-                  保存
-                </Button>
-              </Group>
-            ) : null}
-          </Stack>
+              );
+            }}
+          </form.Subscribe>
         </form>
       </Stack>
     </Card>
@@ -714,13 +884,26 @@ function DeviceSpecEditorSection({
   onSubmit,
   submitting,
 }: DeviceEditorProps) {
-  const [values, setValues] = useState<DeviceSpecFormValues>(initialValues);
-  const [errors, setErrors] = useState<Record<string, string>>({});
+  const zodForm = createTanStackFormZodHelpers(DeviceSpecEditorSchema);
+  const form = useForm({
+    defaultValues: initialValues,
+    validators: {
+      onSubmit: ({ value }) =>
+        toGlobalFormValidationError<DeviceSpecFormValues>(parseDeviceSpecFormValues(value).errors),
+    },
+    onSubmit: async ({ value }) => {
+      const parsed = parseDeviceSpecFormValues(value);
+      if (!parsed.data) {
+        return;
+      }
+
+      await onSubmit(value);
+    },
+  });
 
   useEffect(() => {
-    setValues(initialValues);
-    setErrors({});
-  }, [initialValues]);
+    form.reset(initialValues);
+  }, [form, initialValues]);
 
   return (
     <Card className='feature-card' padding='lg' radius='xl'>
@@ -735,100 +918,164 @@ function DeviceSpecEditorSection({
         <form
           onSubmit={(event) => {
             event.preventDefault();
-            const parsed = parseDeviceSpecFormValues(values);
-            setErrors(parsed.errors);
-            if (!parsed.data) {
-              return;
-            }
-            void onSubmit(values);
+            event.stopPropagation();
+            void form.handleSubmit();
           }}
         >
           <Stack gap='md'>
             <Grid>
               <Grid.Col span={{ base: 12, md: 6 }}>
-                <TextInput
-                  label='メーカー'
-                  value={values.vendor}
-                  onChange={(event) =>
-                    setValues((current) => ({ ...current, vendor: event.currentTarget.value }))
-                  }
-                  error={errors.vendor}
-                  disabled={!canEdit}
-                />
+                <form.Field
+                  name='vendor'
+                  validators={{
+                    onChange: zodForm.getFieldValidator('vendor'),
+                    onSubmit: zodForm.getFieldValidator('vendor'),
+                  }}
+                >
+                  {(field) => (
+                    <TextInput
+                      label='メーカー'
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                      }
+                      error={field.state.meta.errors[0]}
+                      disabled={!canEdit}
+                    />
+                  )}
+                </form.Field>
               </Grid.Col>
               <Grid.Col span={{ base: 12, md: 6 }}>
-                <TextInput
-                  label='型番'
-                  value={values.model}
-                  onChange={(event) =>
-                    setValues((current) => ({ ...current, model: event.currentTarget.value }))
-                  }
-                  error={errors.model}
-                  disabled={!canEdit}
-                />
+                <form.Field
+                  name='model'
+                  validators={{
+                    onChange: zodForm.getFieldValidator('model'),
+                    onSubmit: zodForm.getFieldValidator('model'),
+                  }}
+                >
+                  {(field) => (
+                    <TextInput
+                      label='型番'
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                      }
+                      error={field.state.meta.errors[0]}
+                      disabled={!canEdit}
+                    />
+                  )}
+                </form.Field>
               </Grid.Col>
             </Grid>
 
-            <Select
-              label='種別'
-              data={DEVICE_KINDS.map((value) => ({ value, label: value }))}
-              value={values.kind}
-              onChange={(value) =>
-                setValues((current) => ({
-                  ...current,
-                  kind: (value ?? 'ap') as DeviceSpecFormValues['kind'],
-                }))
-              }
-              allowDeselect={false}
-              disabled={!canEdit}
-            />
+            <form.Field name='kind'>
+              {(field) => (
+                <Select
+                  label='種別'
+                  data={DEVICE_KINDS.map((value) => ({ value, label: value }))}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(value) =>
+                    zodForm.getChangeHandler(field.handleChange)(
+                      (value ?? 'ap') as DeviceSpecFormValues['kind'],
+                    )
+                  }
+                  allowDeselect={false}
+                  disabled={!canEdit}
+                />
+              )}
+            </form.Field>
 
-            <Checkbox.Group
-              label='対応帯域'
-              value={values.supportedBands}
-              onChange={(next) =>
-                setValues((current) => ({
-                  ...current,
-                  supportedBands: next as DeviceSpecFormValues['supportedBands'],
-                }))
-              }
+            <form.Field
+              name='supportedBands'
+              validators={{
+                onSubmit: zodForm.getFieldValidator('supportedBands'),
+              }}
             >
-              <Group mt='xs'>
-                {getBandOptions().map((band) => (
-                  <Checkbox key={band} value={band} label={band} disabled={!canEdit} />
-                ))}
-              </Group>
-            </Checkbox.Group>
-            {errors.supportedBands ? <Text c='red'>{errors.supportedBands}</Text> : null}
+              {(field) => (
+                <>
+                  <Checkbox.Group
+                    label='対応帯域'
+                    value={field.state.value}
+                    onChange={(next) =>
+                      zodForm.getChangeHandler(field.handleChange)(
+                        next as DeviceSpecFormValues['supportedBands'],
+                      )
+                    }
+                  >
+                    <Group mt='xs'>
+                      {getBandOptions().map((band) => (
+                        <Checkbox key={band} value={band} label={band} disabled={!canEdit} />
+                      ))}
+                    </Group>
+                  </Checkbox.Group>
+                  {field.state.meta.errors[0] ? (
+                    <Text c='red'>{field.state.meta.errors[0]}</Text>
+                  ) : null}
+                </>
+              )}
+            </form.Field>
 
-            <Textarea
-              label='既知の注意点'
-              value={values.knownIssues}
-              onChange={(event) =>
-                setValues((current) => ({ ...current, knownIssues: event.currentTarget.value }))
-              }
-              error={errors.knownIssues}
-              minRows={3}
-              disabled={!canEdit}
-            />
+            <form.Field
+              name='knownIssues'
+              validators={{
+                onChange: zodForm.getFieldValidator('knownIssues'),
+                onSubmit: zodForm.getFieldValidator('knownIssues'),
+              }}
+            >
+              {(field) => (
+                <Textarea
+                  label='既知の注意点'
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) =>
+                    zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                  }
+                  error={field.state.meta.errors[0]}
+                  minRows={3}
+                  disabled={!canEdit}
+                />
+              )}
+            </form.Field>
 
-            <Textarea
-              label='メモ'
-              value={values.notes}
-              onChange={(event) =>
-                setValues((current) => ({ ...current, notes: event.currentTarget.value }))
-              }
-              error={errors.notes}
-              minRows={3}
-              disabled={!canEdit}
-            />
+            <form.Field
+              name='notes'
+              validators={{
+                onChange: zodForm.getFieldValidator('notes'),
+                onSubmit: zodForm.getFieldValidator('notes'),
+              }}
+            >
+              {(field) => (
+                <Textarea
+                  label='メモ'
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) =>
+                    zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value)
+                  }
+                  error={field.state.meta.errors[0]}
+                  minRows={3}
+                  disabled={!canEdit}
+                />
+              )}
+            </form.Field>
 
             {canEdit ? (
-              <Group justify='flex-end'>
-                <Button type='submit' loading={submitting}>
-                  保存
-                </Button>
-              </Group>
+              <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+                {([canSubmit, isSubmitting]) => (
+                  <Group justify='flex-end'>
+                    <Button
+                      type='submit'
+                      disabled={!canSubmit}
+                      loading={submitting || Boolean(isSubmitting)}
+                    >
+                      保存
+                    </Button>
+                  </Group>
+                )}
+              </form.Subscribe>
             ) : null}
           </Stack>
         </form>

--- a/apps/web/src/routes/TeamDetailPage.tsx
+++ b/apps/web/src/routes/TeamDetailPage.tsx
@@ -469,23 +469,34 @@ function WifiConfigEditorSection({
   onSubmit,
   submitting,
 }: WifiEditorProps) {
-  const zodForm = createTanStackFormZodHelpers(WifiConfigEditorSchema);
-  const [errors, setErrors] = useState<Partial<Record<keyof WifiConfigFormValues, string>>>({});
-  const [formError, setFormError] = useState<string | null>(null);
+  const existingConfigs = useMemo(
+    () => configs.map((config) => ({ id: config.id, status: config.status })),
+    [configs],
+  );
+  const validateWifiConfigForm = (values: WifiConfigFormValues) => {
+    const parsed = parseWifiConfigFormValues(values, existingConfigs, editingId);
+
+    return toGlobalFormValidationError<WifiConfigFormValues>(parsed.errors, parsed.formError);
+  };
   const form = useForm({
     defaultValues: initialValues,
+    validators: {
+      onChange: ({ value }) => validateWifiConfigForm(value),
+      onSubmit: ({ value }) => validateWifiConfigForm(value),
+    },
+    onSubmit: async ({ value }) => {
+      const parsed = parseWifiConfigFormValues(value, existingConfigs, editingId);
+      if (!parsed.data) {
+        return;
+      }
+
+      await onSubmit(value);
+    },
   });
 
   useEffect(() => {
     form.reset(initialValues);
-    setErrors({});
-    setFormError(null);
   }, [form, initialValues]);
-
-  const clearValidationState = () => {
-    setErrors({});
-    setFormError(null);
-  };
 
   return (
     <Card className='feature-card' padding='lg' radius='xl'>
@@ -498,27 +509,20 @@ function WifiConfigEditorSection({
         </Group>
 
         <form
-          onSubmit={async (event) => {
+          onSubmit={(event) => {
             event.preventDefault();
             event.stopPropagation();
-            const values = form.state.values;
-            const parsed = parseWifiConfigFormValues(
-              values,
-              configs.map((config) => ({ id: config.id, status: config.status })),
-              editingId,
-            );
-
-            setErrors(parsed.errors);
-            setFormError(parsed.formError ?? null);
-            if (!parsed.data) {
-              return;
-            }
-
-            await onSubmit(values);
+            void form.handleSubmit();
           }}
         >
-          <form.Subscribe selector={(state) => state.values}>
-            {(values) => {
+          <form.Subscribe
+            selector={(state) => ({
+              values: state.values,
+              changeFormError: state.errorMap.onChange,
+              submitFormError: state.errorMap.onSubmit,
+            })}
+          >
+            {({ values, changeFormError, submitFormError }) => {
               const sameBandConfigs = configs.filter(
                 (config) => config.band === values.band && config.id !== editingId,
               );
@@ -534,6 +538,7 @@ function WifiConfigEditorSection({
               const knownIssueSummaries = selectedDeviceSpecs
                 .filter((spec) => Boolean(spec.knownIssues))
                 .map((spec) => `${spec.model}: ${spec.knownIssues}`);
+              const formError = changeFormError ?? submitFormError;
 
               return (
                 <Stack gap='md'>
@@ -545,25 +550,14 @@ function WifiConfigEditorSection({
 
                   <Grid>
                     <Grid.Col span={{ base: 12, md: 6 }}>
-                      <form.Field
-                        name='name'
-                        validators={{
-                          onChange: zodForm.getFieldValidator('name'),
-                          onSubmit: zodForm.getFieldValidator('name'),
-                        }}
-                      >
+                      <form.Field name='name'>
                         {(field) => (
                           <TextInput
                             label='構成名'
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(event) => {
-                              clearValidationState();
-                              zodForm.getChangeHandler(field.handleChange)(
-                                event.currentTarget.value,
-                              );
-                            }}
-                            error={field.state.meta.errors[0] ?? errors.name}
+                            onChange={(event) => field.handleChange(event.currentTarget.value)}
+                            error={field.state.meta.errors[0]}
                             disabled={!canEdit}
                           />
                         )}
@@ -577,12 +571,11 @@ function WifiConfigEditorSection({
                             data={PURPOSES.map((value) => ({ value, label: value }))}
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(value) => {
-                              clearValidationState();
-                              zodForm.getChangeHandler(field.handleChange)(
+                            onChange={(value) =>
+                              field.handleChange(
                                 (value ?? 'control') as WifiConfigFormValues['purpose'],
-                              );
-                            }}
+                              )
+                            }
                             allowDeselect={false}
                             disabled={!canEdit}
                           />
@@ -600,12 +593,9 @@ function WifiConfigEditorSection({
                             data={getBandOptions().map((value) => ({ value, label: value }))}
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(value) => {
-                              clearValidationState();
-                              zodForm.getChangeHandler(field.handleChange)(
-                                (value ?? '5GHz') as WifiConfigFormValues['band'],
-                              );
-                            }}
+                            onChange={(value) =>
+                              field.handleChange((value ?? '5GHz') as WifiConfigFormValues['band'])
+                            }
                             allowDeselect={false}
                             disabled={!canEdit}
                           />
@@ -619,11 +609,8 @@ function WifiConfigEditorSection({
                             label='チャンネル'
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(event) => {
-                              clearValidationState();
-                              field.handleChange(event.currentTarget.value);
-                            }}
-                            error={errors.channel}
+                            onChange={(event) => field.handleChange(event.currentTarget.value)}
+                            error={field.state.meta.errors[0]}
                             disabled={!canEdit}
                           />
                         )}
@@ -640,11 +627,8 @@ function WifiConfigEditorSection({
                             }))}
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(value) => {
-                              clearValidationState();
-                              field.handleChange(value ?? String(CHANNEL_WIDTHS[0]));
-                            }}
-                            error={errors.channelWidthMHz}
+                            onChange={(value) => field.handleChange(value ?? String(CHANNEL_WIDTHS[0]))}
+                            error={field.state.meta.errors[0]}
                             allowDeselect={false}
                             disabled={!canEdit}
                           />
@@ -662,12 +646,11 @@ function WifiConfigEditorSection({
                             data={WIFI_CONFIG_ROLES.map((value) => ({ value, label: value }))}
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(value) => {
-                              clearValidationState();
-                              zodForm.getChangeHandler(field.handleChange)(
+                            onChange={(value) =>
+                              field.handleChange(
                                 (value ?? 'primary') as WifiConfigFormValues['role'],
-                              );
-                            }}
+                              )
+                            }
                             allowDeselect={false}
                             disabled={!canEdit}
                           />
@@ -682,12 +665,11 @@ function WifiConfigEditorSection({
                             data={WIFI_CONFIG_STATUSES.map((value) => ({ value, label: value }))}
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(value) => {
-                              clearValidationState();
-                              zodForm.getChangeHandler(field.handleChange)(
+                            onChange={(value) =>
+                              field.handleChange(
                                 (value ?? 'active') as WifiConfigFormValues['status'],
-                              );
-                            }}
+                              )
+                            }
                             allowDeselect={false}
                             disabled={!canEdit}
                           />
@@ -707,14 +689,13 @@ function WifiConfigEditorSection({
                             ]}
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(value) => {
-                              clearValidationState();
-                              zodForm.getChangeHandler(field.handleChange)(
+                            onChange={(value) =>
+                              field.handleChange(
                                 value === null
                                   ? ''
                                   : (value as WifiConfigFormValues['expectedDistanceCategory']),
-                              );
-                            }}
+                              )
+                            }
                             allowDeselect={false}
                             disabled={!canEdit}
                           />
@@ -738,10 +719,7 @@ function WifiConfigEditorSection({
                             ]}
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(value) => {
-                              clearValidationState();
-                              zodForm.getChangeHandler(field.handleChange)(value ?? '');
-                            }}
+                            onChange={(value) => field.handleChange(value ?? '')}
                             allowDeselect={false}
                             disabled={!canEdit}
                           />
@@ -762,10 +740,7 @@ function WifiConfigEditorSection({
                             ]}
                             value={field.state.value}
                             onBlur={field.handleBlur}
-                            onChange={(value) => {
-                              clearValidationState();
-                              zodForm.getChangeHandler(field.handleChange)(value ?? '');
-                            }}
+                            onChange={(value) => field.handleChange(value ?? '')}
                             allowDeselect={false}
                             disabled={!canEdit}
                           />
@@ -774,45 +749,27 @@ function WifiConfigEditorSection({
                     </Grid.Col>
                   </Grid>
 
-                  <form.Field
-                    name='pingTargetIp'
-                    validators={{
-                      onChange: zodForm.getFieldValidator('pingTargetIp'),
-                      onSubmit: zodForm.getFieldValidator('pingTargetIp'),
-                    }}
-                  >
+                  <form.Field name='pingTargetIp'>
                     {(field) => (
                       <TextInput
                         label='Ping 監視先 IP'
                         value={field.state.value}
                         onBlur={field.handleBlur}
-                        onChange={(event) => {
-                          clearValidationState();
-                          zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value);
-                        }}
-                        error={field.state.meta.errors[0] ?? errors.pingTargetIp}
+                        onChange={(event) => field.handleChange(event.currentTarget.value)}
+                        error={field.state.meta.errors[0]}
                         disabled={!canEdit}
                       />
                     )}
                   </form.Field>
 
-                  <form.Field
-                    name='notes'
-                    validators={{
-                      onChange: zodForm.getFieldValidator('notes'),
-                      onSubmit: zodForm.getFieldValidator('notes'),
-                    }}
-                  >
+                  <form.Field name='notes'>
                     {(field) => (
                       <Textarea
                         label='メモ'
                         value={field.state.value}
                         onBlur={field.handleBlur}
-                        onChange={(event) => {
-                          clearValidationState();
-                          zodForm.getChangeHandler(field.handleChange)(event.currentTarget.value);
-                        }}
-                        error={field.state.meta.errors[0] ?? errors.notes}
+                        onChange={(event) => field.handleChange(event.currentTarget.value)}
+                        error={field.state.meta.errors[0]}
                         minRows={3}
                         disabled={!canEdit}
                       />

--- a/apps/web/src/routes/teamManagementRoutes.test.tsx
+++ b/apps/web/src/routes/teamManagementRoutes.test.tsx
@@ -4,6 +4,22 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { appDb, queueIssueReportSync, updateSyncRecordAfterAttempt } from '../lib/db/appDb.js';
 
+const { notificationsShow } = vi.hoisted(() => ({
+  notificationsShow: vi.fn(),
+}));
+
+vi.mock('@mantine/notifications', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mantine/notifications')>();
+
+  return {
+    ...actual,
+    notifications: {
+      ...actual.notifications,
+      show: notificationsShow,
+    },
+  };
+});
+
 vi.mock('../lib/betterAuthClient.js', () => ({
   betterAuthClient: {
     signIn: {
@@ -787,6 +803,7 @@ function renderRoute(
 describe('team management routes', () => {
   beforeEach(() => {
     window.history.replaceState({}, '', '/');
+    notificationsShow.mockClear();
   });
 
   afterEach(async () => {
@@ -1608,6 +1625,158 @@ describe('team management routes', () => {
     });
 
     expect((await screen.findAllByText(/at least 1 character/i)).length).toBeGreaterThan(0);
+  });
+
+  it('operator dashboard の野良 WiFi 手入力成功時は通知を出してフォームをリセットする', async () => {
+    const responses = createOperatorDashboardResponses();
+
+    renderRoute('/app', responses, async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.replace('http://localhost:3000', '');
+
+      if (path === `/api/tournaments/${tournamentId}/observed-wifis` && init?.method === 'POST') {
+        return jsonResponse(
+          {
+            id: '00000000-0000-4000-8000-000000000401',
+            tournamentId,
+            source: 'manual',
+            ssid: null,
+            bssid: null,
+            band: '5GHz',
+            channel: 36,
+            channelWidthMHz: 20,
+            rssi: null,
+            locationLabel: null,
+            observedAt: '2026-04-21T10:00:00.000Z',
+            notes: null,
+            createdAt: '2026-04-21T10:00:00.000Z',
+            updatedAt: '2026-04-21T10:00:00.000Z',
+          },
+          201,
+        );
+      }
+
+      const matched = responses[path];
+
+      if (!matched) {
+        throw new Error(`Unhandled fetch: ${path}`);
+      }
+
+      return jsonResponse(matched.body, matched.status);
+    });
+
+    expect(await screen.findByRole('heading', { name: 'operator dashboard' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('BSSID'), {
+        target: { value: '00:11:22:33:44:66' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: '野良 WiFi を登録' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('BSSID')).toHaveValue('');
+    });
+    expect(notificationsShow).toHaveBeenCalledWith(
+      expect.objectContaining({ title: '野良 WiFi を登録しました' }),
+    );
+  });
+
+  it('operator dashboard の CSV 取込成功時は通知を出して textarea をリセットする', async () => {
+    const responses = createOperatorDashboardResponses();
+
+    renderRoute('/app', responses, async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.replace('http://localhost:3000', '');
+
+      if (
+        path === `/api/tournaments/${tournamentId}/observed-wifis/bulk` &&
+        init?.method === 'POST'
+      ) {
+        return jsonResponse({ count: 1 }, 201);
+      }
+
+      const matched = responses[path];
+
+      if (!matched) {
+        throw new Error(`Unhandled fetch: ${path}`);
+      }
+
+      return jsonResponse(matched.body, matched.status);
+    });
+
+    expect(await screen.findByRole('heading', { name: 'operator dashboard' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('CSV'), {
+        target: {
+          value: [
+            'source,ssid,bssid,band,channel,channelWidthMHz,rssi,locationLabel,observedAt,notes',
+            'manual,Venue WiFi,00:11:22:33:44:55,5GHz,40,20,-68,North Hall,2026-04-21T10:00:00.000Z,scanner',
+          ].join('\n'),
+        },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'CSV を一括登録' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('CSV')).toHaveValue('');
+    });
+    expect(notificationsShow).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'CSV を一括登録しました' }),
+    );
+  });
+
+  it('operator dashboard の notice 作成成功時は通知を出してフォームをリセットする', async () => {
+    const responses = createOperatorDashboardResponses();
+
+    renderRoute('/app', responses, async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.replace('http://localhost:3000', '');
+
+      if (path === `/api/tournaments/${tournamentId}/notices` && init?.method === 'POST') {
+        return jsonResponse(
+          {
+            id: '00000000-0000-4000-8000-000000000402',
+            tournamentId,
+            title: 'Urgent Notice',
+            body: 'Bring spare radios',
+            severity: 'warning',
+            publishedAt: '2026-04-21T10:00:00.000Z',
+            expiresAt: null,
+            createdAt: '2026-04-21T10:00:00.000Z',
+            updatedAt: '2026-04-21T10:00:00.000Z',
+          },
+          201,
+        );
+      }
+
+      const matched = responses[path];
+
+      if (!matched) {
+        throw new Error(`Unhandled fetch: ${path}`);
+      }
+
+      return jsonResponse(matched.body, matched.status);
+    });
+
+    expect(await screen.findByRole('heading', { name: 'operator dashboard' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('title'), { target: { value: 'Urgent Notice' } });
+      fireEvent.change(screen.getByLabelText('body'), {
+        target: { value: 'Bring spare radios' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'お知らせを作成' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('title')).toHaveValue('');
+      expect(screen.getByLabelText('body')).toHaveValue('');
+    });
+    expect(notificationsShow).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'お知らせを作成しました' }),
+    );
   });
 
   it('初回マウント時にオンラインなら pending を自動同期する', async () => {

--- a/apps/web/src/routes/teamManagementRoutes.test.tsx
+++ b/apps/web/src/routes/teamManagementRoutes.test.tsx
@@ -2260,6 +2260,20 @@ describe('team management routes', () => {
     expect(
       await within(form).findByText('帯域 5GHz に対して無効なチャンネルです'),
     ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: 'Still Invalid Config' } });
+    });
+
+    expect(within(form).getByText('帯域 5GHz に対して無効なチャンネルです')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(channelInput, { target: { value: '36' } });
+    });
+
+    expect(
+      within(form).queryByText('帯域 5GHz に対して無効なチャンネルです'),
+    ).not.toBeInTheDocument();
   });
 
   it('WiFi 構成追加フォームで最大 3 件制約エラーを表示する', async () => {
@@ -2302,8 +2316,14 @@ describe('team management routes', () => {
     const form = nameInput.closest('form');
     const saveButton = form?.querySelector('button[type="submit"]');
 
-    if (!(saveButton instanceof HTMLButtonElement)) {
-      throw new Error('wifi config save button not found');
+    if (!(form instanceof HTMLFormElement) || !(saveButton instanceof HTMLButtonElement)) {
+      throw new Error('wifi config form not found');
+    }
+
+    const statusInput = within(form).getAllByDisplayValue('active')[0];
+
+    if (!(statusInput instanceof HTMLInputElement)) {
+      throw new Error('wifi config status input not found');
     }
 
     await act(async () => {
@@ -2311,7 +2331,20 @@ describe('team management routes', () => {
       fireEvent.click(saveButton);
     });
 
-    expect(screen.getByText('WiFi 構成は最大 3 件までです')).toBeInTheDocument();
+    expect(within(form).getByText('WiFi 構成は最大 3 件までです')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: 'Fourth Config Updated' } });
+    });
+
+    expect(within(form).getByText('WiFi 構成は最大 3 件までです')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.mouseDown(statusInput);
+      fireEvent.click(await screen.findByText('disabled'));
+    });
+
+    expect(within(form).queryByText('WiFi 構成は最大 3 件までです')).not.toBeInTheDocument();
   });
 
   it.each([

--- a/apps/web/src/routes/teamManagementRoutes.test.tsx
+++ b/apps/web/src/routes/teamManagementRoutes.test.tsx
@@ -1570,6 +1570,54 @@ describe('team management routes', () => {
     expect(screen.getByRole('heading', { name: 'operator dashboard' })).toBeInTheDocument();
   });
 
+  it('operator dashboard の CSV 取込 submit error は CSV カード直下に表示する', async () => {
+    const responses = createOperatorDashboardResponses();
+
+    renderRoute('/app', responses, async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.replace('http://localhost:3000', '');
+
+      if (
+        path === `/api/tournaments/${tournamentId}/observed-wifis/bulk` &&
+        init?.method === 'POST'
+      ) {
+        return jsonResponse({ error: { code: 'API_ERROR', message: 'status 400' } }, 400);
+      }
+
+      const matched = responses[path];
+
+      if (!matched) {
+        throw new Error(`Unhandled fetch: ${path}`);
+      }
+
+      return jsonResponse(matched.body, matched.status);
+    });
+
+    expect(await screen.findByRole('heading', { name: 'operator dashboard' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('CSV'), {
+        target: {
+          value: [
+            'source,ssid,bssid,band,channel,channelWidthMHz,rssi,locationLabel,observedAt,notes',
+            'manual,Venue WiFi,00:11:22:33:44:55,5GHz,40,20,-68,North Hall,2026-04-21T10:00:00.000Z,scanner',
+          ].join('\n'),
+        },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'CSV を一括登録' }));
+    });
+
+    const csvCard = screen.getByRole('heading', { name: 'CSV 取込' }).closest('.feature-card');
+    const observedWifiCard = screen
+      .getByRole('heading', { name: '野良 WiFi 手入力登録' })
+      .closest('.feature-card');
+
+    expect(csvCard).not.toBeNull();
+    expect(observedWifiCard).not.toBeNull();
+    expect(await within(csvCard as HTMLElement).findByText('API request failed')).toBeInTheDocument();
+    expect(within(observedWifiCard as HTMLElement).queryByText('API request failed')).not.toBeInTheDocument();
+  });
+
   it.each([
     400, 401, 403, 409, 422,
   ])('operator dashboard の野良 WiFi 手入力は API %s 応答時にエラー alert を表示する', async (status) => {

--- a/apps/web/src/routes/teamManagementRoutes.test.tsx
+++ b/apps/web/src/routes/teamManagementRoutes.test.tsx
@@ -1585,6 +1585,31 @@ describe('team management routes', () => {
     expect(screen.getByRole('heading', { name: 'operator dashboard' })).toBeInTheDocument();
   });
 
+  it('operator dashboard の野良 WiFi 手入力は field error を表示する', async () => {
+    renderRoute('/app', createOperatorDashboardResponses());
+
+    expect(await screen.findByRole('heading', { name: 'operator dashboard' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('BSSID'), { target: { value: 'invalid-bssid' } });
+      fireEvent.click(screen.getByRole('button', { name: '野良 WiFi を登録' }));
+    });
+
+    expect(await screen.findByText(/invalid/i)).toBeInTheDocument();
+  });
+
+  it('operator dashboard の notice 作成は field error を表示する', async () => {
+    renderRoute('/app', createOperatorDashboardResponses());
+
+    expect(await screen.findByRole('heading', { name: 'operator dashboard' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'お知らせを作成' }));
+    });
+
+    expect((await screen.findAllByText(/at least 1 character/i)).length).toBeGreaterThan(0);
+  });
+
   it('初回マウント時にオンラインなら pending を自動同期する', async () => {
     const record = await queueIssueReportSync(tournamentId, {
       teamId: ownTeamId,
@@ -1899,6 +1924,53 @@ describe('team management routes', () => {
       screen.getByText('5GHz の control link は AP-9000 を優先し混雑を避ける'),
     ).toBeInTheDocument();
     expect(screen.getByText('AP-9000: DFS 切替で瞬断しやすい')).toBeInTheDocument();
+  });
+
+  it('team editor は submit 時に field error を表示する', async () => {
+    renderRoute(`/tournaments/${tournamentId}/teams/${ownTeamId}`, createOwnTeamDetailResponses());
+
+    expect(await screen.findByRole('heading', { name: 'Alpha' })).toBeInTheDocument();
+
+    const nameInput = screen.getByLabelText('チーム名');
+    const form = nameInput.closest('form');
+    const saveButton = screen.getByRole('button', { name: 'チーム情報を保存' });
+
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error('team form not found');
+    }
+
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: '' } });
+      fireEvent.click(saveButton);
+    });
+
+    expect(await within(form).findByText(/at least 1 character/i)).toBeInTheDocument();
+  });
+
+  it('機材仕様フォームは supportedBands の field error を表示する', async () => {
+    renderRoute(`/tournaments/${tournamentId}/teams/${ownTeamId}`, createOwnTeamDetailResponses());
+
+    expect(await screen.findByRole('heading', { name: 'Alpha' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '新しい機材仕様を追加' }));
+    });
+
+    const modelInput = await screen.findByLabelText('型番');
+    const form = modelInput.closest('form');
+    const saveButton = form?.querySelector('button[type="submit"]');
+
+    if (!(form instanceof HTMLFormElement) || !(saveButton instanceof HTMLButtonElement)) {
+      throw new Error('device spec form not found');
+    }
+
+    await act(async () => {
+      fireEvent.change(modelInput, { target: { value: 'AP-01' } });
+      fireEvent.click(screen.getByRole('checkbox', { name: '5GHz' }));
+      fireEvent.click(saveButton);
+    });
+
+    expect(await within(form).findByText(/at least 1 element/i)).toBeInTheDocument();
   });
 
   it('team viewer は閲覧専用 UI となり private 情報と編集導線を表示しない', async () => {


### PR DESCRIPTION
## 概要

Issue #40 対応。チーム管理画面 (\`TeamDetailPage\`) と運営ダッシュボード (\`AppDashboardPage\`) に残っていた \`useState\` + 手書き parse 関数ベースのフォームを TanStack Form + Zod に統一しました。

Closes #40

## 主要変更点

- **TeamDetailPage**: Team editor / WifiConfig editor / DeviceSpec editor を TanStack Form に移行。帯域/チャンネル整合性・最大 3 件制約を form validation として表現。
- **AppDashboardPage**: ObservedWifi 手入力・CSV 取込・お知らせ作成/編集フォームを TanStack Form に移行。行単位エラー表示は既存仕様のまま維持。
- **teamManagement.ts**: \`parseTeamFormValues\` / \`parseWifiConfigFormValues\` / \`parseDeviceSpecFormValues\` を Zod schema + business rule validator に分割・整理。
- edit/new 切替の初期値再同期を TanStack Form の \`reset\` パターンで統一。

## 検証結果

- \`pnpm --filter @wifiman/web lint\`: 通過
- \`pnpm --filter @wifiman/web typecheck\`: 通過
- \`pnpm --filter @wifiman/web test\`: 通過

## 残留リスク

- テスト実行時に React Testing Library の \`act()\` 警告が残存しています。機能上の問題はありませんが、今後のテスト改善タスクで対処予定です。